### PR TITLE
fix: use getOAuthSession in OAuth path to resolve session timing bug

### DIFF
--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -160,20 +160,9 @@ const oauthProvider = new OAuthProvider({
 			const baseUrl = `${url.protocol}//${url.host}`
 
 			// Use the shared server factory with OAuth auth messages
-			const { server, setContext } = createMcpServer(env, baseUrl, {
+			const { server } = createMcpServer(env, baseUrl, {
 				authMessages: buildOAuthAuthMessages(),
 			})
-
-			// Set session from OAuth context
-			const auth = getMcpAuthContext()
-			if (auth?.props) {
-				const props = auth.props as unknown as { username: string; sessionKey: string }
-				if (props.sessionKey && props.username) {
-					setContext({
-						session: { username: props.username, sessionKey: props.sessionKey },
-					})
-				}
-			}
 
 			return createMcpHandler(server)(request, env, ctx)
 		},

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { registerPrompts } from './prompts/analysis'
 import { registerResources } from './resources/lastfm'
 import {
 	registerAuthenticatedTools,
+	registerAuthenticatedToolsWithOAuth,
 	registerPublicTools,
 	buildSessionAuthMessages,
 	type AuthSession,
@@ -75,8 +76,14 @@ export function createMcpServer(env: Env, initialBaseUrl: string, options?: { au
 	registerPublicTools(server, cachedClient, getBaseUrl)
 
 	// Register authenticated tools with appropriate auth messages
-	const authMessages = options?.authMessages ?? buildSessionAuthMessages(getBaseUrl, getSessionId)
-	registerAuthenticatedTools(server, cachedClient, getSession, authMessages)
+	if (options?.authMessages) {
+		// OAuth path: use getOAuthSession which defers getMcpAuthContext() into tool execution
+		registerAuthenticatedToolsWithOAuth(server, cachedClient, getBaseUrl)
+	} else {
+		// Session-based path: use context.session set via setContext()
+		const authMessages = buildSessionAuthMessages(getBaseUrl, getSessionId)
+		registerAuthenticatedTools(server, cachedClient, getSession, authMessages)
+	}
 
 	// Register resources
 	registerResources(server, cachedClient, getSession)


### PR DESCRIPTION
Possible fix?
OAuth login works fine, but then every tool that needs auth fails with "Authentication Required."

I think the issue is that  `index-oauth.ts`: `getMcpAuthContext()` gets called 
before `createMcpHandler()`  has run. So AsyncLocalStorage is never set up, and he session never gets set.

Both `registerAuthenticatedToolsWithOAuth()` and `getOAuthSession` 
already exist in the codebase, unused. They do the same `getMcpAuthContext()` call, but inside the tool handler where 
it actually works.
What I did:
-   In `server.ts`: in OAuth mode, use `registerAuthenticatedToolsWithOAuth`  instead of passing a dead session getter
- In `index-oauth.ts`: removed the broken `getMcpAuthContext()` pre-call and the `setContext` block that never goes off


I'm a little bit new to this, so please do reply if I got it wrong :) Got another PR coming as well