### PR TITLE
fix: OAuth browser flow — route unauthenticated /mcp through OAuth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
+.worktrees/

--- a/docs/superpowers/plans/2026-03-15-oauth-flow-fix.md
+++ b/docs/superpowers/plans/2026-03-15-oauth-flow-fix.md
@@ -1,0 +1,1095 @@
+# OAuth Flow Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix unauthenticated `/mcp` requests to return `401 + WWW-Authenticate` instead of routing through `handleUnauthenticatedMcp()`, so MCP clients (Claude Code, Claude Desktop, opencode) automatically open the browser for OAuth instead of showing a copy-paste URL.
+
+**Architecture:** Remove the `if (!hasOAuthToken)` short-circuit in `src/index-oauth.ts` that bypasses the OAuth provider for unauthenticated requests. Add a `Mcp-Session-Id` header + KV lookup before falling through to the OAuth provider, preserving existing manual-login sessions. All other unauthenticated requests fall through to the OAuth provider which returns the correct `401`. Also add `Access-Control-Expose-Headers: Mcp-Session-Id` to `handleSessionBasedMcp` which currently omits it.
+
+**Tech Stack:** Cloudflare Workers, `@cloudflare/workers-oauth-provider`, Vitest with `@cloudflare/vitest-pool-workers`, TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-03-15-oauth-flow-design.md`
+
+**Note on test file names:** The spec names the test file `test/oauth-flow.spec.ts`. This plan uses `test/index-oauth.test.ts` (existing file, extended) and `test/oauth-discovery.test.ts` (new) and `test/oauth-roundtrip.test.ts` (new) to match the existing naming convention in the project. The spec is the source of truth for *what* to test; this plan is the source of truth for *where*.
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `src/index-oauth.ts` | Modify | (1) Add `Access-Control-Expose-Headers` to `handleSessionBasedMcp`; (2) Replace the `/mcp` routing block — remove `if (!hasOAuthToken)` branch and delete `handleUnauthenticatedMcp` function; (3) Add `Mcp-Session-Id` header + KV lookup before falling through to OAuth provider |
+| `test/index-oauth.test.ts` | Modify | Add ABOUTME header; replace unauthenticated-200 tests with correct 401 tests; add Mcp-Session-Id header tests and regression tests; preserve Access-Control-Expose-Headers coverage |
+| `test/oauth-discovery.test.ts` | Create | Tests for `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` metadata |
+| `test/oauth-roundtrip.test.ts` | Create | Full OAuth round-trip integration test (register client → authorize → callback → exchange code → use token); covers spec test case 7 (valid bearer token → 200) |
+
+**Do not touch:**
+- `src/index.ts` — legacy session path, out of scope
+- `src/auth/oauth-handler.ts` — working correctly
+- `src/auth/lastfm.ts` — working correctly
+- `src/auth/jwt.ts` — working correctly
+- `src/mcp/server.ts` — no changes needed once routing is fixed
+
+---
+
+## Chunk 1: Update and Extend Tests (TDD First)
+
+Write all tests before touching implementation. Verify failing tests fail for the right reason before moving to Chunk 2.
+
+---
+
+### Task 0: Add ABOUTME header to test/index-oauth.test.ts
+
+CLAUDE.md requires all code files to start with a 2-line `ABOUTME:` comment. The existing file uses a JSDoc block instead.
+
+**Files:**
+- Modify: `test/index-oauth.test.ts`
+
+- [ ] **Step 1: Replace the JSDoc header at line 1**
+
+Find:
+```typescript
+/**
+ * Tests for the OAuth entry point (src/index-oauth.ts)
+ *
+ * Tests unauthenticated MCP access, session-based auth, and OAuth routing.
+ */
+```
+
+Replace with:
+```typescript
+// ABOUTME: Tests for the OAuth entry point (src/index-oauth.ts).
+// ABOUTME: Covers unauthenticated 401 routing, session-based auth, OAuth routing, and regression for copy-paste URL bug.
+```
+
+- [ ] **Step 2: Verify the file still compiles**
+
+Run: `npx vitest run test/index-oauth.test.ts --reporter=verbose 2>&1 | tail -5`
+
+Expected: Same test results as before (no import/parse errors).
+
+---
+
+### Task 1: Replace the broken unauthenticated-200 tests in test/index-oauth.test.ts
+
+The existing `'/mcp endpoint - unauthenticated access'` describe block (lines 11–104) contains **three tests that assert status 200 for unauthenticated requests** — this is the broken behavior we are fixing. All three must be replaced.
+
+The three tests being removed:
+1. "should handle initialize request without authentication" — asserts 200 (wrong after fix)
+2. "should preserve existing session ID from header" — sends `Mcp-Session-Id` that is NOT in KV, asserts 200 (wrong after fix; this is an unknown session and must fall through to 401)
+3. "should expose Mcp-Session-Id in Access-Control-Expose-Headers" — asserts 200 for unauthenticated (wrong after fix)
+
+**Files:**
+- Modify: `test/index-oauth.test.ts`
+
+- [ ] **Step 1: Replace the entire `'/mcp endpoint - unauthenticated access'` describe block**
+
+Find the block starting at line 11 (`describe('/mcp endpoint - unauthenticated access', () => {`) through line 104 (its closing `})`). Replace the entire block with:
+
+```typescript
+describe('/mcp endpoint - unauthenticated access', () => {
+  const initBody = JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'TestClient', version: '1.0.0' },
+    },
+    id: 1,
+  })
+  const mcpHeaders = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  }
+
+  it('should return 401 when no auth is provided', async () => {
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: mcpHeaders,
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('should include WWW-Authenticate header pointing to OAuth metadata', async () => {
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: mcpHeaders,
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(401)
+    const wwwAuth = response.headers.get('WWW-Authenticate')
+    expect(wwwAuth).not.toBeNull()
+    expect(wwwAuth).toContain('Bearer')
+    expect(wwwAuth).toContain('resource_metadata')
+    expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
+  })
+
+  it('should return 401 when Mcp-Session-Id header has no matching KV session', async () => {
+    // An unknown Mcp-Session-Id (not in KV) must fall through to OAuth → 401.
+    // The old behavior returned 200 by routing all requests through handleUnauthenticatedMcp.
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: { ...mcpHeaders, 'Mcp-Session-Id': 'unknown-session-not-in-kv' },
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(401)
+    const wwwAuth = response.headers.get('WWW-Authenticate')
+    expect(wwwAuth).toContain('Bearer')
+  })
+
+  it('should not include a /login?session_id= URL in the response body', async () => {
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: mcpHeaders,
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    const body = await response.clone().text()
+    expect(body).not.toContain('/login?session_id=')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify the replaced tests now fail**
+
+Run: `npx vitest run test/index-oauth.test.ts --reporter=verbose 2>&1`
+
+Expected: The 4 tests in the replaced block FAIL (implementation not changed yet). The session-based auth, OAuth, and static endpoint tests should still PASS.
+
+---
+
+### Task 2: Add Mcp-Session-Id header + Access-Control-Expose-Headers tests
+
+**Files:**
+- Modify: `test/index-oauth.test.ts`
+
+- [ ] **Step 1: Add a new describe block after the existing `'/mcp endpoint - session-based auth'` block**
+
+```typescript
+describe('/mcp endpoint - Mcp-Session-Id header routing', () => {
+  const initBody = JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'TestClient', version: '1.0.0' },
+    },
+    id: 1,
+  })
+
+  it('should use session-based auth when Mcp-Session-Id header has a valid KV session', async () => {
+    const sessionId = 'test-mcp-header-valid-session'
+    await env.MCP_SESSIONS.put(
+      `session:${sessionId}`,
+      JSON.stringify({
+        userId: 'testuser',
+        sessionKey: 'test-session-key',
+        username: 'testuser',
+        timestamp: Date.now(),
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        sessionId,
+      }),
+    )
+
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'Mcp-Session-Id': sessionId,
+      },
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Mcp-Session-Id')).toBe(sessionId)
+  })
+
+  it('should expose Mcp-Session-Id in Access-Control-Expose-Headers for session-based responses', async () => {
+    const sessionId = 'test-mcp-header-expose-session'
+    await env.MCP_SESSIONS.put(
+      `session:${sessionId}`,
+      JSON.stringify({
+        userId: 'testuser',
+        sessionKey: 'test-session-key',
+        username: 'testuser',
+        timestamp: Date.now(),
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        sessionId,
+      }),
+    )
+
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'Mcp-Session-Id': sessionId,
+      },
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('Mcp-Session-Id')
+  })
+
+  it('should return 401 when Mcp-Session-Id header session is expired', async () => {
+    // handleSessionBasedMcp checks expiresAt and returns 401 with error: 'session_expired'
+    const sessionId = 'test-mcp-header-expired-session'
+    await env.MCP_SESSIONS.put(
+      `session:${sessionId}`,
+      JSON.stringify({
+        userId: 'testuser',
+        sessionKey: 'test-session-key',
+        username: 'testuser',
+        timestamp: Date.now() - 40 * 24 * 60 * 60 * 1000,
+        expiresAt: Date.now() - 10 * 24 * 60 * 60 * 1000, // expired 10 days ago
+        sessionId,
+      }),
+    )
+
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: initBody,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'Mcp-Session-Id': sessionId,
+      },
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    // Expired session → handleSessionBasedMcp returns 401 with session_expired error
+    // (This is existing behavior in handleSessionBasedMcp lines 52–63, not changed by the fix)
+    expect(response.status).toBe(401)
+    const result = (await response.json()) as { error: string }
+    expect(result.error).toBe('session_expired')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify new tests fail (not yet implemented)**
+
+Run: `npx vitest run test/index-oauth.test.ts --reporter=verbose 2>&1`
+
+Expected:
+- "should use session-based auth when Mcp-Session-Id header has a valid KV session" — **check the result carefully**. The current `handleUnauthenticatedMcp()` code does look up `session:{mcpSessionId}` in KV and returns 200 if found. This test may already PASS before the fix. Note whether it passes or fails — do not skip this step.
+- "should expose Mcp-Session-Id in Access-Control-Expose-Headers for session-based responses" — likely FAILS because `handleSessionBasedMcp` does not yet add `Access-Control-Expose-Headers`.
+- "should return 401 when Mcp-Session-Id header session is expired" — may PASS (expired sessions already handled in `handleSessionBasedMcp`).
+
+---
+
+### Task 3: Add session_id param valid-session test and bearer token test
+
+These are spec test cases 4 and 7, which were missing from the original plan.
+
+**Files:**
+- Modify: `test/index-oauth.test.ts`
+
+- [ ] **Step 1: Add a test inside the existing `'/mcp endpoint - session-based auth'` describe block**
+
+After the existing test "should return 401 when session_id does not exist in KV", add:
+
+```typescript
+it('should return 200 when session_id param has a valid KV session', async () => {
+  const sessionId = 'test-session-id-param-valid'
+  await env.MCP_SESSIONS.put(
+    `session:${sessionId}`,
+    JSON.stringify({
+      userId: 'testuser',
+      sessionKey: 'test-session-key',
+      username: 'testuser',
+      timestamp: Date.now(),
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      sessionId,
+    }),
+  )
+
+  const request = new Request(`http://example.com/mcp?session_id=${sessionId}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'TestClient', version: '1.0.0' },
+      },
+      id: 1,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+  })
+
+  const ctx = createExecutionContext()
+  const response = await worker.fetch(request, env, ctx)
+  await waitOnExecutionContext(ctx)
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get('Mcp-Session-Id')).toBe(sessionId)
+})
+```
+
+- [ ] **Step 2: Add a bearer token test inside the existing `'/mcp endpoint - OAuth auth'` describe block**
+
+After the existing "should include WWW-Authenticate header for 401 responses" test, add:
+
+```typescript
+it('should not return a /login?session_id= URL in OAuth path tool responses', async () => {
+  // Even with a valid bearer token but no Last.fm session props,
+  // the OAuth path must never fall back to session-based auth messages.
+  // Note: this test uses an invalid token (401 expected), not a valid one.
+  // The key assertion is that the body never contains the copy-paste URL.
+  const request = new Request('http://example.com/mcp', {
+    method: 'POST',
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'get_recent_tracks', arguments: {} },
+      id: 1,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Authorization: 'Bearer invalid-token',
+    },
+  })
+
+  const ctx = createExecutionContext()
+  const response = await worker.fetch(request, env, ctx)
+  await waitOnExecutionContext(ctx)
+
+  const body = await response.clone().text()
+  expect(body).not.toContain('/login?session_id=')
+})
+```
+
+- [ ] **Step 3: Run tests to see current state**
+
+Run: `npx vitest run test/index-oauth.test.ts --reporter=verbose 2>&1`
+
+Note which tests pass and fail. The "session_id valid KV" test should PASS (that path already works). The bearer token body test should PASS (OAuth provider 401 response doesn't contain a login URL).
+
+---
+
+### Task 4: Create OAuth discovery endpoint tests
+
+**Files:**
+- Create: `test/oauth-discovery.test.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+// ABOUTME: Tests for OAuth discovery endpoints required by the MCP OAuth 2.1 spec.
+// ABOUTME: Verifies /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server return correct metadata.
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { describe, it, expect } from 'vitest'
+import worker from '../src/index-oauth'
+
+describe('OAuth Discovery Endpoints', () => {
+  describe('/.well-known/oauth-protected-resource', () => {
+    it('should return 200 with JSON content type', async () => {
+      const request = new Request('http://example.com/.well-known/oauth-protected-resource')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toContain('application/json')
+    })
+
+    it('should include required resource metadata fields', async () => {
+      const request = new Request('http://example.com/.well-known/oauth-protected-resource')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      const data = (await response.json()) as Record<string, unknown>
+
+      // resource must be the base URL only (no /mcp path) for audience validation
+      expect(data.resource).toBe('http://example.com')
+      expect((data.authorization_servers as string[]).includes('http://example.com')).toBe(true)
+      expect((data.bearer_methods_supported as string[]).includes('header')).toBe(true)
+    })
+
+    it('should not include /mcp path in resource field', async () => {
+      // workers-oauth-provider validates audience against base URL only.
+      // Including /mcp would cause token audience mismatch errors on every request.
+      const request = new Request('http://example.com/.well-known/oauth-protected-resource')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      const data = (await response.json()) as Record<string, unknown>
+      expect(data.resource as string).not.toContain('/mcp')
+    })
+  })
+
+  describe('/.well-known/oauth-authorization-server', () => {
+    it('should return 200 with JSON content type', async () => {
+      const request = new Request('http://example.com/.well-known/oauth-authorization-server')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toContain('application/json')
+    })
+
+    it('should include all MCP-required authorization server fields', async () => {
+      const request = new Request('http://example.com/.well-known/oauth-authorization-server')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      const data = (await response.json()) as Record<string, unknown>
+
+      expect(data.issuer).toBeTruthy()
+      expect(data.authorization_endpoint).toBeTruthy()
+      expect(data.token_endpoint).toBeTruthy()
+      expect((data.response_types_supported as string[]).includes('code')).toBe(true)
+      expect((data.grant_types_supported as string[]).includes('authorization_code')).toBe(true)
+      expect((data.code_challenge_methods_supported as string[]).includes('S256')).toBe(true)
+    })
+
+    it('should have authorization_endpoint pointing to /authorize', async () => {
+      const request = new Request('http://example.com/.well-known/oauth-authorization-server')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      const data = (await response.json()) as Record<string, unknown>
+      expect(data.authorization_endpoint as string).toContain('/authorize')
+    })
+
+    it('should have token_endpoint pointing to /oauth/token', async () => {
+      const request = new Request('http://example.com/.well-known/oauth-authorization-server')
+      const ctx = createExecutionContext()
+      const response = await worker.fetch(request, env, ctx)
+      await waitOnExecutionContext(ctx)
+
+      const data = (await response.json()) as Record<string, unknown>
+      expect(data.token_endpoint as string).toContain('/oauth/token')
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify discovery tests pass (these endpoints already work)**
+
+Run: `npx vitest run test/oauth-discovery.test.ts --reporter=verbose 2>&1`
+
+Expected: All tests PASS. These endpoints are served by `@cloudflare/workers-oauth-provider` (auth server metadata) and `oauth-handler.ts` (protected resource metadata), both of which are already correct. If any test fails, note the failure — do not proceed until you understand why.
+
+---
+
+### Task 5: Add the regression test for copy-paste URLs
+
+This is the key regression test: lock in that `POST /mcp` with no auth never returns a copy-paste URL again.
+
+**Files:**
+- Modify: `test/index-oauth.test.ts`
+
+- [ ] **Step 1: Add a regression describe block at the end of the file**
+
+```typescript
+describe('Regression: no copy-paste login URLs for OAuth clients', () => {
+  it('POST /mcp with no auth should never return a /login?session_id= URL in body', async () => {
+    // This is the exact broken behavior we are fixing.
+    // Before the fix: returns 200 with "Click this link: /login?session_id=..."
+    // After the fix: returns 401 with WWW-Authenticate header
+    const request = new Request('http://example.com/mcp', {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name: 'get_recent_tracks', arguments: {} },
+        id: 1,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(401)
+    const body = await response.clone().text()
+    expect(body).not.toContain('/login?session_id=')
+    expect(body).not.toContain('Click this link')
+    expect(body).not.toContain('Sign in with your Last.fm')
+  })
+
+  it('POST /mcp with valid session_id param still returns 200 (not affected by fix)', async () => {
+    const sessionId = 'regression-test-valid-session'
+    await env.MCP_SESSIONS.put(
+      `session:${sessionId}`,
+      JSON.stringify({
+        userId: 'testuser',
+        sessionKey: 'test-session-key',
+        username: 'testuser',
+        timestamp: Date.now(),
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        sessionId,
+      }),
+    )
+
+    const request = new Request(`http://example.com/mcp?session_id=${sessionId}`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'TestClient', version: '1.0.0' },
+        },
+        id: 1,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+    })
+
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('GET /login still works (manual login path not affected)', async () => {
+    // The /login route is handled by LastfmOAuthHandler and must not be broken
+    const request = new Request('http://example.com/login')
+    const ctx = createExecutionContext()
+    const response = await worker.fetch(request, env, ctx)
+    await waitOnExecutionContext(ctx)
+
+    // /login redirects to Last.fm auth (302) — confirms the manual path still works
+    expect([302, 400, 500]).toContain(response.status)
+    // It should NOT return 404
+    expect(response.status).not.toBe(404)
+  })
+})
+```
+
+- [ ] **Step 2: Run all tests to get the full pre-fix baseline**
+
+Run: `npx vitest run test/index-oauth.test.ts test/oauth-discovery.test.ts --reporter=verbose 2>&1`
+
+Save the output. Expected: Several tests in `index-oauth.test.ts` FAIL (those asserting 401 for unauthenticated requests). Discovery tests PASS. This is your baseline — after the fix, all should pass.
+
+- [ ] **Step 3: Commit the tests**
+
+```bash
+git add test/index-oauth.test.ts test/oauth-discovery.test.ts
+git commit -m "test: update index-oauth tests and add OAuth discovery tests for routing fix"
+```
+
+---
+
+### Task 6: Create full OAuth round-trip integration test
+
+This test covers spec test case 7 (valid bearer token → 200) and proves the complete flow works end-to-end: register a client, authorize, callback, exchange code for token, use token to call an MCP endpoint.
+
+Mocks the Last.fm `getSessionKey` API call so we don't need a real Last.fm account.
+
+**Files:**
+- Create: `test/oauth-roundtrip.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+```typescript
+// ABOUTME: Full OAuth round-trip integration test for the MCP OAuth 2.1 flow.
+// ABOUTME: Covers client registration, authorization, callback, token exchange, and authenticated MCP request.
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import worker from '../src/index-oauth'
+
+// Mock the Last.fm auth module so we don't need a real Last.fm account.
+// The mock intercepts getSessionKey() which is called during /lastfm-callback.
+vi.mock('../src/auth/lastfm', () => ({
+  LastfmAuth: vi.fn().mockImplementation(() => ({
+    getAuthUrl: (callbackUrl: string) =>
+      `https://www.last.fm/api/auth/?api_key=test-key&cb=${encodeURIComponent(callbackUrl)}`,
+    getSessionKey: vi.fn().mockResolvedValue({
+      sessionKey: 'mock-lastfm-session-key',
+      username: 'testuser',
+    }),
+  })),
+}))
+
+/** Generate a PKCE code_verifier and its SHA-256 base64url code_challenge */
+async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
+  const verifier = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32))))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+  const challenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+  return { verifier, challenge }
+}
+
+describe('Full OAuth Round-Trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('completes the full OAuth flow: register → authorize → callback → token → MCP request', async () => {
+    const baseUrl = 'http://example.com'
+    const redirectUri = 'http://localhost:9999/callback'
+
+    // ── Step 1: Register a test OAuth client ────────────────────────────
+    const registerRequest = new Request(`${baseUrl}/oauth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_name: 'Test MCP Client',
+        redirect_uris: [redirectUri],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none', // public client (PKCE)
+      }),
+    })
+    const regCtx = createExecutionContext()
+    const regResponse = await worker.fetch(registerRequest, env, regCtx)
+    await waitOnExecutionContext(regCtx)
+
+    expect(regResponse.status).toBe(201)
+    const { client_id: clientId } = (await regResponse.json()) as { client_id: string }
+    expect(clientId).toBeTruthy()
+
+    // ── Step 2: Start authorization (GET /authorize) ─────────────────────
+    const { verifier, challenge } = await generatePKCE()
+    const state = crypto.randomUUID()
+    const authorizeUrl = new URL(`${baseUrl}/authorize`)
+    authorizeUrl.searchParams.set('response_type', 'code')
+    authorizeUrl.searchParams.set('client_id', clientId)
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri)
+    authorizeUrl.searchParams.set('code_challenge', challenge)
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+    authorizeUrl.searchParams.set('state', state)
+
+    const authCtx = createExecutionContext()
+    const authResponse = await worker.fetch(new Request(authorizeUrl.toString()), env, authCtx)
+    await waitOnExecutionContext(authCtx)
+
+    // Should redirect to Last.fm
+    expect(authResponse.status).toBe(302)
+    const lastfmRedirectUrl = authResponse.headers.get('Location')
+    expect(lastfmRedirectUrl).toContain('last.fm')
+    expect(lastfmRedirectUrl).toContain('lastfm-callback')
+
+    // Extract state token from the Last.fm callback URL embedded in the redirect
+    const cbUrlMatch = lastfmRedirectUrl!.match(/cb=([^&]+)/)
+    expect(cbUrlMatch).not.toBeNull()
+    const callbackUrl = decodeURIComponent(cbUrlMatch![1])
+    const stateToken = new URL(callbackUrl).searchParams.get('state')
+    expect(stateToken).toBeTruthy()
+
+    // ── Step 3: Simulate Last.fm callback ────────────────────────────────
+    const lastfmCallbackUrl = `${baseUrl}/lastfm-callback?token=mock-lastfm-token&state=${stateToken}`
+    const callbackCtx = createExecutionContext()
+    const callbackResponse = await worker.fetch(new Request(lastfmCallbackUrl), env, callbackCtx)
+    await waitOnExecutionContext(callbackCtx)
+
+    // Should redirect back to our redirect_uri with an authorization code
+    expect(callbackResponse.status).toBe(302)
+    const redirectBack = callbackResponse.headers.get('Location')
+    expect(redirectBack).toBeTruthy()
+    expect(redirectBack).toContain(redirectUri)
+
+    const codeUrl = new URL(redirectBack!)
+    const code = codeUrl.searchParams.get('code')
+    expect(code).toBeTruthy()
+
+    // ── Step 4: Exchange code for access token ───────────────────────────
+    const tokenRequest = new Request(`${baseUrl}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        code_verifier: verifier,
+      }).toString(),
+    })
+    const tokenCtx = createExecutionContext()
+    const tokenResponse = await worker.fetch(tokenRequest, env, tokenCtx)
+    await waitOnExecutionContext(tokenCtx)
+
+    expect(tokenResponse.status).toBe(200)
+    const { access_token: accessToken } = (await tokenResponse.json()) as { access_token: string }
+    expect(accessToken).toBeTruthy()
+
+    // ── Step 5: Use access token to call MCP endpoint ────────────────────
+    // This is spec test case 7: valid bearer token → 200
+    const mcpRequest = new Request(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'TestClient', version: '1.0.0' },
+        },
+        id: 1,
+      }),
+    })
+    const mcpCtx = createExecutionContext()
+    const mcpResponse = await worker.fetch(mcpRequest, env, mcpCtx)
+    await waitOnExecutionContext(mcpCtx)
+
+    // Valid token → MCP handler responds with 200
+    expect(mcpResponse.status).toBe(200)
+
+    // Body must not contain a copy-paste URL
+    const body = await mcpResponse.clone().text()
+    expect(body).not.toContain('/login?session_id=')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify the round-trip test fails (no implementation yet)**
+
+Run: `npx vitest run test/oauth-roundtrip.test.ts --reporter=verbose 2>&1`
+
+Expected: The test FAILS because `POST /mcp` without auth (before the routing fix) returns 200 with a copy-paste URL instead of going through OAuth. Alternatively it may fail at the "valid token → 200" assertion if `handleUnauthenticatedMcp` is still in place. Note the exact failure point.
+
+- [ ] **Step 3: Commit the round-trip test**
+
+```bash
+git add test/oauth-roundtrip.test.ts
+git commit -m "test: add full OAuth round-trip integration test"
+```
+
+---
+
+## Chunk 2: Implement the Fix
+
+---
+
+### Task 7: Add Access-Control-Expose-Headers to handleSessionBasedMcp
+
+`handleSessionBasedMcp` sets `Mcp-Session-Id` but not `Access-Control-Expose-Headers`. Cross-origin clients need both to read the session ID. After the fix, `Mcp-Session-Id` header clients go through this function, so it must expose the header.
+
+The test for this was written in Task 2 ("should expose Mcp-Session-Id in Access-Control-Expose-Headers for session-based responses"). **Run that test now to confirm it fails before making this change:**
+
+Run: `npx vitest run test/index-oauth.test.ts -t "should expose Mcp-Session-Id in Access-Control-Expose-Headers" --reporter=verbose 2>&1`
+
+Expected: FAIL — `handleSessionBasedMcp` does not yet add `Access-Control-Expose-Headers`. Then apply the fix below.
+
+**Files:**
+- Modify: `src/index-oauth.ts`
+
+- [ ] **Step 1: Find the response construction in `handleSessionBasedMcp` (around lines 84–93)**
+
+The current code:
+```typescript
+	// Add session ID to response headers
+	const newHeaders = new Headers(response.headers)
+	newHeaders.set('Mcp-Session-Id', sessionId)
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: newHeaders,
+	})
+```
+
+Replace with:
+```typescript
+	// Add session ID to response headers and expose it for cross-origin clients
+	const newHeaders = new Headers(response.headers)
+	newHeaders.set('Mcp-Session-Id', sessionId)
+	newHeaders.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: newHeaders,
+	})
+```
+
+- [ ] **Step 2: Build check**
+
+Run: `npm run build 2>&1`
+
+Expected: No errors.
+
+---
+
+### Task 8: Fix request routing — remove handleUnauthenticatedMcp
+
+**Files:**
+- Modify: `src/index-oauth.ts`
+
+- [ ] **Step 1: Delete the `handleUnauthenticatedMcp` function**
+
+Find and delete the entire function from the opening comment through its closing brace. The function starts at line 95 with this comment and ends at line 149:
+
+```typescript
+/**
+ * Handle MCP request without authentication (for clients that don't support OAuth)
+ * Public tools work; authenticated tools prompt for login
+ */
+async function handleUnauthenticatedMcp(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+	// ... entire function body ...
+}
+```
+
+Delete all 51 lines of this function (lines 95–149). After deletion the file should jump from the end of `handleSessionBasedMcp` directly to the `// Server metadata` comment or the `oauthProvider` declaration.
+
+- [ ] **Step 2: Replace the `/mcp` routing block**
+
+Find this block (now around lines 310–328 after the function deletion — search for `// Check if this is an MCP request`):
+
+```typescript
+		// Check if this is an MCP request
+		if (url.pathname === '/mcp') {
+			const sessionId = url.searchParams.get('session_id')
+			const hasOAuthToken = request.headers.get('Authorization')?.startsWith('Bearer ')
+
+			if (sessionId) {
+				// Use session-based auth for Claude Desktop
+				return handleSessionBasedMcp(request, env, ctx, sessionId)
+			}
+
+			if (!hasOAuthToken) {
+				// No OAuth token - handle as unauthenticated MCP request
+				// Public tools work; authenticated tools prompt for login
+				return handleUnauthenticatedMcp(request, env, ctx)
+			}
+
+			// Has Bearer token - fall through to OAuth provider for validation
+		}
+```
+
+Replace with:
+
+```typescript
+		// Check if this is an MCP request
+		if (url.pathname === '/mcp') {
+			const sessionId = url.searchParams.get('session_id')
+
+			if (sessionId) {
+				// Explicit session_id param → session-based auth (manual login flow)
+				return handleSessionBasedMcp(request, env, ctx, sessionId)
+			}
+
+			// Check for an existing session via Mcp-Session-Id header.
+			// Clients that previously authenticated via the manual login flow
+			// send this header to resume their session.
+			const mcpSessionId = request.headers.get('Mcp-Session-Id')
+			if (mcpSessionId) {
+				const sessionDataStr = await env.MCP_SESSIONS.get(`session:${mcpSessionId}`)
+				if (sessionDataStr) {
+					return handleSessionBasedMcp(request, env, ctx, mcpSessionId)
+				}
+			}
+
+			// No valid session found. Fall through to the OAuth provider.
+			// - Requests with a valid Bearer token: OAuth provider authenticates them.
+			// - Requests with no/invalid token: OAuth provider returns 401 + WWW-Authenticate,
+			//   which triggers the MCP client's built-in browser-based OAuth flow.
+		}
+```
+
+- [ ] **Step 3: Check for unused imports**
+
+After deleting `handleUnauthenticatedMcp`, check line 10:
+```typescript
+import { buildOAuthAuthMessages } from './mcp/tools'
+```
+
+Search in the file for other uses of `buildOAuthAuthMessages`. It is still used inside the `oauthProvider` `apiHandler` on line 164 (`authMessages: buildOAuthAuthMessages()`). Keep the import.
+
+Also check that no other function references `handleUnauthenticatedMcp`:
+
+```bash
+grep -n "handleUnauthenticatedMcp\|buildOAuthAuthMessages" src/index-oauth.ts
+```
+
+Expected output: Only the `buildOAuthAuthMessages` import line (line ~10) and its usage inside `oauthProvider.apiHandler` (line ~164). Zero occurrences of `handleUnauthenticatedMcp`. If any appear, remove them.
+
+- [ ] **Step 4: Build check**
+
+Run: `npm run build 2>&1`
+
+Expected: No TypeScript errors. If there are any remaining references to `handleUnauthenticatedMcp` they will appear as errors — fix them.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run: `npx vitest run test/index-oauth.test.ts test/oauth-discovery.test.ts test/oauth-roundtrip.test.ts --reporter=verbose 2>&1`
+
+Expected: All tests PASS. Check each test by name:
+- "should return 401 when no auth is provided" ✓
+- "should include WWW-Authenticate header pointing to OAuth metadata" ✓
+- "should return 401 when Mcp-Session-Id header has no matching KV session" ✓
+- "should not include a /login?session_id= URL in the response body" ✓
+- "should use session-based auth when Mcp-Session-Id header has a valid KV session" ✓
+- "should expose Mcp-Session-Id in Access-Control-Expose-Headers for session-based responses" ✓
+- "should return 401 when Mcp-Session-Id header session is expired" ✓
+- "POST /mcp with no auth should never return a /login?session_id= URL in body" ✓
+
+If any test fails, diagnose using the failure message before proceeding.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `npm test 2>&1`
+
+Expected: All tests pass. If any pre-existing tests fail, investigate — do NOT skip or delete them without understanding why.
+
+- [ ] **Step 8: Commit the fix**
+
+```bash
+git add src/index-oauth.ts
+git commit -m "fix: route unauthenticated /mcp requests through OAuth provider for browser-based auth
+
+Previously, requests with no bearer token and no session_id were sent to
+handleUnauthenticatedMcp() which returned a copy-paste /login?session_id= URL.
+Now they fall through to the OAuth provider which returns 401 + WWW-Authenticate,
+triggering MCP clients (Claude Code, Claude Desktop, opencode) to open the
+browser automatically for OAuth.
+
+Also adds Access-Control-Expose-Headers: Mcp-Session-Id to handleSessionBasedMcp
+so cross-origin clients can read the session ID header.
+
+Preserves Mcp-Session-Id header + KV lookup for clients with existing
+manual-login sessions."
+```
+
+---
+
+## Chunk 3: Manual Verification
+
+---
+
+### Task 9: Manual end-to-end verification
+
+Automated tests prove the HTTP-level behavior is correct. This task verifies the actual client experience.
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Start the dev server**
+
+Run in background: `npm run dev`
+
+Wait for the message: `⎔ Starting local server...` / `Ready on http://localhost:8787`
+
+- [ ] **Step 2: Verify the 401 response**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8787/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
+```
+
+Expected output: `401`
+
+- [ ] **Step 3: Verify the WWW-Authenticate header**
+
+```bash
+curl -s -D - -o /dev/null -X POST http://localhost:8787/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}' \
+  | grep -i www-authenticate
+```
+
+Expected: `WWW-Authenticate: Bearer resource_metadata="http://localhost:8787/.well-known/oauth-protected-resource"`
+
+- [ ] **Step 4: Verify the discovery endpoints**
+
+```bash
+curl -s http://localhost:8787/.well-known/oauth-protected-resource | python3 -m json.tool
+curl -s http://localhost:8787/.well-known/oauth-authorization-server | python3 -m json.tool
+```
+
+Expected: Both return valid JSON. The authorization server metadata must include `authorization_endpoint`, `token_endpoint`, `response_types_supported` (with `"code"`), `grant_types_supported` (with `"authorization_code"`), `code_challenge_methods_supported` (with `"S256"`).
+
+- [ ] **Step 5: Test with MCP Inspector**
+
+```bash
+npx @modelcontextprotocol/inspector http://localhost:8787/mcp
+```
+
+Expected: MCP Inspector detects the 401 response, fetches OAuth metadata, and prompts to open a browser for authorization — NOT a copy-paste URL. Complete the authorization flow and confirm authenticated tools work.
+
+If it does not open a browser:
+1. Check the MCP Inspector output for the exact error message.
+2. Run `curl -s http://localhost:8787/.well-known/oauth-authorization-server | python3 -m json.tool` and confirm `authorization_endpoint` and `token_endpoint` are present.
+3. Run `curl -s http://localhost:8787/.well-known/oauth-protected-resource | python3 -m json.tool` and confirm `authorization_servers` contains the base URL.
+4. If MCP Inspector shows "no OAuth metadata found", the `WWW-Authenticate` header format may be wrong — re-run step 3 of this task and compare to the expected value exactly.
+5. Do not deploy until manual verification passes.
+
+---
+
+## Deployment
+
+After all tests pass and manual verification succeeds:
+
+- [ ] **Deploy to production**
+
+```bash
+npm run deploy:prod
+```
+
+- [ ] **Verify production**
+
+```bash
+curl -s -D - -o /dev/null -X POST https://lastfm-mcp.com/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}' \
+  | grep -i www-authenticate
+```
+
+Expected: `WWW-Authenticate: Bearer resource_metadata="https://lastfm-mcp.com/.well-known/oauth-protected-resource"`

--- a/docs/superpowers/specs/2026-03-15-oauth-flow-design.md
+++ b/docs/superpowers/specs/2026-03-15-oauth-flow-design.md
@@ -1,0 +1,247 @@
+# OAuth Flow Fix: Design Spec
+
+**Date:** 2026-03-15
+**Status:** Approved
+
+---
+
+## Problem
+
+All MCP clients (Claude Code, Claude Desktop, opencode) receive a copy-paste URL (`/login?session_id=...`) when they need to authenticate, instead of having the browser open automatically.
+
+The correct MCP OAuth 2.1 behavior:
+1. Client sends unauthenticated `POST /mcp`
+2. Server returns `401 WWW-Authenticate: Bearer resource_metadata="https://host/.well-known/oauth-protected-resource"`
+3. Client fetches `/.well-known/oauth-protected-resource`, then `/.well-known/oauth-authorization-server`
+4. Client opens browser to `/authorize`
+5. User authorizes on Last.fm → `completeAuthorization()` runs → token issued to client
+6. Client retries with bearer token — no copy/paste required
+
+---
+
+## Confirmed Root Cause
+
+In `src/index-oauth.ts` lines 371–375, there is an explicit short-circuit:
+
+```typescript
+if (!hasOAuthToken) {
+    // No OAuth token - handle as unauthenticated MCP request
+    return handleUnauthenticatedMcp(request, env, ctx)
+}
+```
+
+When a request arrives at `/mcp` with no bearer token and no `session_id` query param, this sends it to `handleUnauthenticatedMcp()` instead of the OAuth provider. The OAuth provider never runs, never returns `401`, and clients never see the `WWW-Authenticate` header that would trigger their browser flow.
+
+`handleUnauthenticatedMcp()` creates an MCP server with `session: null`. In `server.ts` line 78, when no `authMessages` option is passed, it defaults to `buildSessionAuthMessages()`:
+
+```typescript
+const authMessages = options?.authMessages ?? buildSessionAuthMessages(getBaseUrl, getSessionId)
+```
+
+This generates the `/login?session_id=...` copy-paste URL that all clients are currently seeing.
+
+**Secondary issue:** `handleUnauthenticatedMcp()` also performs a valuable KV lookup for existing sessions via `Mcp-Session-Id` header — for clients that previously authenticated via manual login. This behavior must be preserved.
+
+---
+
+## Goals
+
+- All supported clients (Claude Code, Claude Desktop, opencode) trigger an automatic browser open for first-time authentication
+- No copy-paste `/login?session_id=...` URLs shown for clients that support MCP OAuth
+- Clients with existing sessions (via `Mcp-Session-Id` header + KV) continue to work without re-authenticating
+- Legacy `session_id` query param path continues to work unchanged
+- Comprehensive automated tests that lock in the fix and prevent regression
+
+## Non-Goals
+
+- Rebuilding the OAuth layer from scratch
+- Changing the manual login / session-based auth path (`/login`, `/callback`, `session_id` param)
+- Supporting new MCP clients beyond the three listed
+
+---
+
+## Architecture
+
+No structural changes. The existing OAuth infrastructure is correct. We are fixing the request routing in `index-oauth.ts`.
+
+### Fixed Request Routing Logic
+
+**Current (broken):**
+```
+POST /mcp
+  ├─ has session_id param → handleSessionBasedMcp()
+  ├─ has no bearer token → handleUnauthenticatedMcp()  ← THE BUG
+  └─ has bearer token → oauthProvider.fetch()
+```
+
+**Fixed:**
+```
+POST /mcp
+  ├─ has session_id param → handleSessionBasedMcp()
+  ├─ has Mcp-Session-Id header + valid KV session → handleSessionBasedMcp()  ← preserve existing sessions
+  └─ everything else → oauthProvider.fetch()
+       ├─ valid bearer token → authenticated MCP handler
+       └─ no/invalid bearer token → 401 + WWW-Authenticate  ← triggers browser flow
+```
+
+The `WWW-Authenticate` header injection at lines 390–398 already exists and is correct:
+```typescript
+newHeaders.set('WWW-Authenticate', `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`)
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/index-oauth.ts` | Remove the `if (!hasOAuthToken)` branch; add `Mcp-Session-Id` + KV lookup before falling through to OAuth provider |
+| `src/mcp/server.ts` | Verify `buildSessionAuthMessages` is not the default when called from the OAuth path (it won't be once the routing is fixed) |
+
+### Files Explicitly Out of Scope
+
+| File | Reason |
+|------|--------|
+| `src/index.ts` | Legacy session path — do not touch |
+| `src/auth/jwt.ts` | Working correctly |
+| `src/auth/lastfm.ts` | Working correctly |
+| `src/auth/oauth-handler.ts` | Working correctly — authorize, callback, protected resource metadata all correct |
+| `/.well-known/oauth-authorization-server` | Served by `@cloudflare/workers-oauth-provider` automatically — verify contents in tests but no code change expected |
+
+---
+
+## Implementation Steps
+
+### Step 1: Fix routing in `index-oauth.ts`
+
+Replace the `if (!hasOAuthToken)` short-circuit with a `Mcp-Session-Id` header lookup:
+
+```typescript
+// Check if this is an MCP request
+if (url.pathname === '/mcp') {
+    const sessionId = url.searchParams.get('session_id')
+
+    if (sessionId) {
+        // Explicit session_id param → session-based auth
+        return handleSessionBasedMcp(request, env, ctx, sessionId)
+    }
+
+    // Check for existing session via Mcp-Session-Id header (clients from previous manual login)
+    const mcpSessionId = request.headers.get('Mcp-Session-Id')
+    if (mcpSessionId) {
+        const sessionDataStr = await env.MCP_SESSIONS.get(`session:${mcpSessionId}`)
+        if (sessionDataStr) {
+            return handleSessionBasedMcp(request, env, ctx, mcpSessionId)
+        }
+    }
+
+    // No valid session → fall through to OAuth provider
+    // - Valid bearer token: OAuth provider authenticates and serves MCP
+    // - No bearer token: OAuth provider returns 401 + WWW-Authenticate (triggers browser flow)
+}
+```
+
+### Step 2: Verify `/.well-known/oauth-authorization-server`
+
+Fetch the live endpoint and confirm it contains all MCP-required fields. This is auto-generated by `@cloudflare/workers-oauth-provider` — expected to be correct, but must be verified. Required fields:
+- `issuer`
+- `authorization_endpoint`
+- `token_endpoint`
+- `response_types_supported` (must include `"code"`)
+- `grant_types_supported` (must include `"authorization_code"`)
+- `code_challenge_methods_supported` (must include `"S256"`)
+
+### Step 3: Write tests (see Testing section)
+
+Write tests before verifying the fix works end-to-end.
+
+---
+
+## Testing
+
+Testing is a first-class requirement. This fix has been attempted before and failed. Tests must prove the fix works.
+
+### Unit Tests — `test/oauth-flow.spec.ts` (new file)
+
+**1. Unauthenticated request returns 401**
+- `POST /mcp` with no `Authorization` header and no `session_id` param
+- Assert: response status is `401`
+- Assert: `WWW-Authenticate` header is present
+- Assert: header value is `Bearer resource_metadata="https://host/.well-known/oauth-protected-resource"`
+- Assert: response body does NOT contain `/login?session_id=`
+
+**2. Protected resource metadata is correct**
+- `GET /.well-known/oauth-protected-resource`
+- Assert: status `200`
+- Assert: `resource` field equals base URL (no path)
+- Assert: `authorization_servers` includes base URL
+- Assert: `bearer_methods_supported` includes `"header"`
+
+**3. Authorization server metadata is correct**
+- `GET /.well-known/oauth-authorization-server`
+- Assert: status `200`
+- Assert: all required MCP fields present: `issuer`, `authorization_endpoint`, `token_endpoint`, `response_types_supported` (includes `"code"`), `grant_types_supported` (includes `"authorization_code"`), `code_challenge_methods_supported` (includes `"S256"`)
+
+**4. Session_id param path still works**
+- `POST /mcp?session_id=known-session` with valid KV session
+- Assert: status `200`, not `401`
+- Assert: `Mcp-Session-Id` header in response
+
+**5. Mcp-Session-Id header path still works**
+- `POST /mcp` with `Mcp-Session-Id: known-session` header and valid KV session
+- Assert: status `200`, not `401`
+
+**6. Mcp-Session-Id header with unknown session falls through to 401**
+- `POST /mcp` with `Mcp-Session-Id: unknown-session` header (not in KV)
+- Assert: status `401` with `WWW-Authenticate` header
+
+**7. Valid bearer token is accepted**
+- `POST /mcp` with `Authorization: Bearer valid-token`
+- Assert: reaches MCP handler (status `200`)
+- Assert: no copy-paste URL in response body
+
+**8. Tool responses in OAuth path never contain session-based URL**
+- Simulate `get_recent_tracks` tool call with valid OAuth bearer token but no Last.fm session props
+- Assert: response does not contain `/login?session_id=`
+
+### Integration Test — Full OAuth Round-Trip
+
+Simulate what a conforming MCP client does:
+
+1. `POST /mcp` (no auth) → assert `401` + `WWW-Authenticate`
+2. `GET /.well-known/oauth-protected-resource` → assert valid JSON with `authorization_servers`
+3. `GET /.well-known/oauth-authorization-server` → assert valid metadata
+4. `GET /authorize?client_id=...&redirect_uri=...&code_challenge=...&code_challenge_method=S256&response_type=code` → assert redirect to Last.fm auth URL
+5. Simulate Last.fm callback: `GET /lastfm-callback?token=mock-token&state=stored-state` (mock Last.fm `auth.getSession` API)
+6. Assert: `completeAuthorization()` is called, redirect issued to client redirect_uri
+7. Client exchanges code: `POST /oauth/token` with code → assert token response with `access_token`
+8. `POST /mcp` with `Authorization: Bearer <access_token>` → assert `200` with MCP capabilities
+
+### Regression Tests
+
+- `POST /mcp` with no auth returns `401` — not `200` with a `/login?session_id=...` string in the body
+- `POST /mcp?session_id=valid` with valid KV session returns `200`
+- `GET /login` still works and redirects to Last.fm
+
+---
+
+## Deployment
+
+No feature flags needed — this is a routing fix, not a new feature.
+
+**Verification in staging:**
+1. Run `npm run dev` locally
+2. Use MCP Inspector (`npx @modelcontextprotocol/inspector`) to connect to `http://localhost:8787/mcp`
+3. Confirm MCP Inspector shows OAuth prompt and opens browser, not a copy-paste URL
+4. Complete the flow and confirm authenticated tools work
+
+**Rollback:** Reverting this change restores the previous behavior (copy-paste URLs). The session-based path and manual login path are unchanged, so rollback has no collateral damage.
+
+---
+
+## Success Criteria
+
+1. All automated tests pass
+2. `POST /mcp` with no auth returns `401` with correct `WWW-Authenticate` header (verified by test)
+3. Full OAuth round-trip integration test passes (verified by test)
+4. Manual verification: connecting MCP Inspector to `/mcp` triggers OAuth browser open, not a copy-paste URL
+5. Manual verification: existing session via `session_id` param or `Mcp-Session-Id` header continues to work
+6. No tool response in the OAuth path contains `/login?session_id=`

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -84,6 +84,7 @@ async function handleSessionBasedMcp(request: Request, env: Env, ctx: ExecutionC
 	// Add session ID to response headers
 	const newHeaders = new Headers(response.headers)
 	newHeaders.set('Mcp-Session-Id', sessionId)
+	newHeaders.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
 
 	return new Response(response.body, {
 		status: response.status,

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -92,61 +92,6 @@ async function handleSessionBasedMcp(request: Request, env: Env, ctx: ExecutionC
 	})
 }
 
-/**
- * Handle MCP request without authentication (for clients that don't support OAuth)
- * Public tools work; authenticated tools prompt for login
- */
-async function handleUnauthenticatedMcp(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-	const url = new URL(request.url)
-	const baseUrl = `${url.protocol}//${url.host}`
-
-	// Generate a session ID for this client (allows them to authenticate later)
-	// Check for existing session ID in header first
-	let sessionId = request.headers.get('Mcp-Session-Id')
-	if (!sessionId) {
-		sessionId = crypto.randomUUID()
-	}
-
-	console.log(
-		`[MCP] Unauthenticated path - sessionId: ${sessionId}, source: ${request.headers.get('Mcp-Session-Id') ? 'header' : 'generated'}`,
-	)
-
-	// Check KV for existing session data (user may have authenticated via /login)
-	let session: { username: string; sessionKey: string } | null = null
-	const sessionDataStr = await env.MCP_SESSIONS.get(`session:${sessionId}`)
-	if (sessionDataStr) {
-		const sessionData: SessionData = JSON.parse(sessionDataStr)
-		if (!sessionData.expiresAt || Date.now() <= sessionData.expiresAt) {
-			session = {
-				username: sessionData.username,
-				sessionKey: sessionData.sessionKey,
-			}
-			console.log(`[MCP] Found existing session for ${sessionData.username} via Mcp-Session-Id header`)
-		}
-	}
-
-	// Create MCP server with session context (if found)
-	const { server, setContext } = createMcpServer(env, baseUrl)
-
-	setContext({
-		sessionId,
-		session,
-	})
-
-	const handler = createMcpHandler(server, { route: '/mcp' })
-	const response = await handler(request, env, ctx)
-
-	// Add session ID to response headers so client can use it for subsequent requests
-	const newHeaders = new Headers(response.headers)
-	newHeaders.set('Mcp-Session-Id', sessionId)
-	newHeaders.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
-
-	return new Response(response.body, {
-		status: response.status,
-		statusText: response.statusText,
-		headers: newHeaders,
-	})
-}
 
 /**
  * Create the OAuth provider instance
@@ -361,20 +306,25 @@ Sitemap: https://lastfm-mcp.com/sitemap.xml`,
 		// Check if this is an MCP request
 		if (url.pathname === '/mcp') {
 			const sessionId = url.searchParams.get('session_id')
-			const hasOAuthToken = request.headers.get('Authorization')?.startsWith('Bearer ')
 
 			if (sessionId) {
-				// Use session-based auth for Claude Desktop
+				// Explicit session_id param → session-based auth
 				return handleSessionBasedMcp(request, env, ctx, sessionId)
 			}
 
-			if (!hasOAuthToken) {
-				// No OAuth token - handle as unauthenticated MCP request
-				// Public tools work; authenticated tools prompt for login
-				return handleUnauthenticatedMcp(request, env, ctx)
+			// Check for existing session via Mcp-Session-Id header
+			// (clients that previously authenticated via manual /login flow)
+			const mcpSessionId = request.headers.get('Mcp-Session-Id')
+			if (mcpSessionId) {
+				const sessionDataStr = await env.MCP_SESSIONS.get(`session:${mcpSessionId}`)
+				if (sessionDataStr) {
+					return handleSessionBasedMcp(request, env, ctx, mcpSessionId)
+				}
 			}
 
-			// Has Bearer token - fall through to OAuth provider for validation
+			// No valid session → fall through to OAuth provider
+			// - Valid bearer token: OAuth provider authenticates and serves MCP
+			// - No bearer token: OAuth provider returns 401 + WWW-Authenticate (triggers browser OAuth flow)
 		}
 
 		// Strip resource parameter from token requests to prevent audience mismatch

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -1,5 +1,5 @@
-// ABOUTME: OAuth 2.1 entry point for MCP. All /mcp requests require authentication.
-// ABOUTME: Clients (mcp-remote, Claude Code, OpenCode) get the OAuth browser flow automatically via 401.
+// ABOUTME: Hybrid auth entry point supporting both OAuth 2.0 and session-based authentication.
+// ABOUTME: Routes requests to MCP handler or legacy session auth based on client type.
 import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import type { ExecutionContext } from '@cloudflare/workers-types'
 import { createMcpHandler, getMcpAuthContext } from 'agents/mcp'
@@ -84,6 +84,62 @@ async function handleSessionBasedMcp(request: Request, env: Env, ctx: ExecutionC
 	// Add session ID to response headers
 	const newHeaders = new Headers(response.headers)
 	newHeaders.set('Mcp-Session-Id', sessionId)
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: newHeaders,
+	})
+}
+
+/**
+ * Handle MCP request without authentication (for clients that don't support OAuth)
+ * Public tools work; authenticated tools prompt for login
+ */
+async function handleUnauthenticatedMcp(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+	const url = new URL(request.url)
+	const baseUrl = `${url.protocol}//${url.host}`
+
+	// Generate a session ID for this client (allows them to authenticate later)
+	// Check for existing session ID in header first
+	let sessionId = request.headers.get('Mcp-Session-Id')
+	if (!sessionId) {
+		sessionId = crypto.randomUUID()
+	}
+
+	console.log(
+		`[MCP] Unauthenticated path - sessionId: ${sessionId}, source: ${request.headers.get('Mcp-Session-Id') ? 'header' : 'generated'}`,
+	)
+
+	// Check KV for existing session data (user may have authenticated via /login)
+	let session: { username: string; sessionKey: string } | null = null
+	const sessionDataStr = await env.MCP_SESSIONS.get(`session:${sessionId}`)
+	if (sessionDataStr) {
+		const sessionData: SessionData = JSON.parse(sessionDataStr)
+		if (!sessionData.expiresAt || Date.now() <= sessionData.expiresAt) {
+			session = {
+				username: sessionData.username,
+				sessionKey: sessionData.sessionKey,
+			}
+			console.log(`[MCP] Found existing session for ${sessionData.username} via Mcp-Session-Id header`)
+		}
+	}
+
+	// Create MCP server with session context (if found)
+	const { server, setContext } = createMcpServer(env, baseUrl)
+
+	setContext({
+		sessionId,
+		session,
+	})
+
+	const handler = createMcpHandler(server, { route: '/mcp' })
+	const response = await handler(request, env, ctx)
+
+	// Add session ID to response headers so client can use it for subsequent requests
+	const newHeaders = new Headers(response.headers)
+	newHeaders.set('Mcp-Session-Id', sessionId)
+	newHeaders.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
 
 	return new Response(response.body, {
 		status: response.status,
@@ -307,15 +363,20 @@ Sitemap: https://lastfm-mcp.com/sitemap.xml`,
 		// Check if this is an MCP request
 		if (url.pathname === '/mcp') {
 			const sessionId = url.searchParams.get('session_id')
+			const hasOAuthToken = request.headers.get('Authorization')?.startsWith('Bearer ')
 
 			if (sessionId) {
-				// Use session-based auth for Claude Desktop (legacy path)
+				// Use session-based auth for Claude Desktop
 				return handleSessionBasedMcp(request, env, ctx, sessionId)
 			}
 
-			// No Bearer token and no session_id: fall through to OAuth provider.
-			// The provider returns 401 and we augment it with WWW-Authenticate below,
-			// which triggers mcp-remote / Claude Code / OpenCode to start the OAuth flow.
+			if (!hasOAuthToken) {
+				// No OAuth token - handle as unauthenticated MCP request
+				// Public tools work; authenticated tools prompt for login
+				return handleUnauthenticatedMcp(request, env, ctx)
+			}
+
+			// Has Bearer token - fall through to OAuth provider for validation
 		}
 
 		// Strip resource parameter from token requests to prevent audience mismatch

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Hybrid auth entry point supporting both OAuth 2.0 and session-based authentication.
-// ABOUTME: Routes requests to MCP handler or legacy session auth based on client type.
+// ABOUTME: OAuth 2.1 entry point for MCP. All /mcp requests require authentication.
+// ABOUTME: Clients (mcp-remote, Claude Code, OpenCode) get the OAuth browser flow automatically via 401.
 import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import type { ExecutionContext } from '@cloudflare/workers-types'
 import { createMcpHandler, getMcpAuthContext } from 'agents/mcp'
@@ -84,62 +84,6 @@ async function handleSessionBasedMcp(request: Request, env: Env, ctx: ExecutionC
 	// Add session ID to response headers
 	const newHeaders = new Headers(response.headers)
 	newHeaders.set('Mcp-Session-Id', sessionId)
-
-	return new Response(response.body, {
-		status: response.status,
-		statusText: response.statusText,
-		headers: newHeaders,
-	})
-}
-
-/**
- * Handle MCP request without authentication (for clients that don't support OAuth)
- * Public tools work; authenticated tools prompt for login
- */
-async function handleUnauthenticatedMcp(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-	const url = new URL(request.url)
-	const baseUrl = `${url.protocol}//${url.host}`
-
-	// Generate a session ID for this client (allows them to authenticate later)
-	// Check for existing session ID in header first
-	let sessionId = request.headers.get('Mcp-Session-Id')
-	if (!sessionId) {
-		sessionId = crypto.randomUUID()
-	}
-
-	console.log(
-		`[MCP] Unauthenticated path - sessionId: ${sessionId}, source: ${request.headers.get('Mcp-Session-Id') ? 'header' : 'generated'}`,
-	)
-
-	// Check KV for existing session data (user may have authenticated via /login)
-	let session: { username: string; sessionKey: string } | null = null
-	const sessionDataStr = await env.MCP_SESSIONS.get(`session:${sessionId}`)
-	if (sessionDataStr) {
-		const sessionData: SessionData = JSON.parse(sessionDataStr)
-		if (!sessionData.expiresAt || Date.now() <= sessionData.expiresAt) {
-			session = {
-				username: sessionData.username,
-				sessionKey: sessionData.sessionKey,
-			}
-			console.log(`[MCP] Found existing session for ${sessionData.username} via Mcp-Session-Id header`)
-		}
-	}
-
-	// Create MCP server with session context (if found)
-	const { server, setContext } = createMcpServer(env, baseUrl)
-
-	setContext({
-		sessionId,
-		session,
-	})
-
-	const handler = createMcpHandler(server, { route: '/mcp' })
-	const response = await handler(request, env, ctx)
-
-	// Add session ID to response headers so client can use it for subsequent requests
-	const newHeaders = new Headers(response.headers)
-	newHeaders.set('Mcp-Session-Id', sessionId)
-	newHeaders.set('Access-Control-Expose-Headers', 'Mcp-Session-Id')
 
 	return new Response(response.body, {
 		status: response.status,
@@ -363,20 +307,15 @@ Sitemap: https://lastfm-mcp.com/sitemap.xml`,
 		// Check if this is an MCP request
 		if (url.pathname === '/mcp') {
 			const sessionId = url.searchParams.get('session_id')
-			const hasOAuthToken = request.headers.get('Authorization')?.startsWith('Bearer ')
 
 			if (sessionId) {
-				// Use session-based auth for Claude Desktop
+				// Use session-based auth for Claude Desktop (legacy path)
 				return handleSessionBasedMcp(request, env, ctx, sessionId)
 			}
 
-			if (!hasOAuthToken) {
-				// No OAuth token - handle as unauthenticated MCP request
-				// Public tools work; authenticated tools prompt for login
-				return handleUnauthenticatedMcp(request, env, ctx)
-			}
-
-			// Has Bearer token - fall through to OAuth provider for validation
+			// No Bearer token and no session_id: fall through to OAuth provider.
+			// The provider returns 401 and we augment it with WWW-Authenticate below,
+			// which triggers mcp-remote / Claude Code / OpenCode to start the OAuth flow.
 		}
 
 		// Strip resource parameter from token requests to prevent audience mismatch

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -2,9 +2,9 @@
 // ABOUTME: Routes requests to MCP handler or legacy session auth based on client type.
 import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import type { ExecutionContext } from '@cloudflare/workers-types'
-import { createMcpHandler, getMcpAuthContext } from 'agents/mcp'
+import { createMcpHandler } from 'agents/mcp'
 
-import { LastfmOAuthHandler } from './auth/oauth-handler'
+import { LastfmOAuthHandler, type LastfmUserProps } from './auth/oauth-handler'
 import { MARKETING_PAGE_HTML } from './marketing-page'
 import { createMcpServer } from './mcp/server'
 import { buildOAuthAuthMessages } from './mcp/tools'
@@ -164,15 +164,13 @@ const oauthProvider = new OAuthProvider({
 				authMessages: buildOAuthAuthMessages(),
 			})
 
-			// Set session from OAuth context
-			const auth = getMcpAuthContext()
-			if (auth?.props) {
-				const props = auth.props as unknown as { username: string; sessionKey: string }
-				if (props.sessionKey && props.username) {
-					setContext({
-						session: { username: props.username, sessionKey: props.sessionKey },
-					})
-				}
+			// Set session from OAuth context.
+			// workers-oauth-provider injects the user props from completeAuthorization() into ctx.props.
+			const props = (ctx as unknown as { props?: LastfmUserProps }).props
+			if (props?.sessionKey && props?.username) {
+				setContext({
+					session: { username: props.username, sessionKey: props.sessionKey },
+				})
 			}
 
 			return createMcpHandler(server)(request, env, ctx)

--- a/test/index-oauth.test.ts
+++ b/test/index-oauth.test.ts
@@ -1,105 +1,90 @@
-/**
- * Tests for the OAuth entry point (src/index-oauth.ts)
- *
- * Tests unauthenticated MCP access, session-based auth, and OAuth routing.
- */
+// ABOUTME: Tests for the OAuth entry point (src/index-oauth.ts).
+// ABOUTME: Covers unauthenticated 401 routing, session-based auth, OAuth routing, and regression for copy-paste URL bug.
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { describe, it, expect } from 'vitest'
 import worker from '../src/index-oauth'
 
 describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 	describe('/mcp endpoint - unauthenticated access', () => {
-		it('should handle initialize request without authentication', async () => {
-			const initRequest = {
-				jsonrpc: '2.0',
-				method: 'initialize',
-				params: {
-					protocolVersion: '2024-11-05',
-					capabilities: {},
-					clientInfo: { name: 'TestClient', version: '1.0.0' },
-				},
-				id: 1,
-			}
+		const initBody = JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'initialize',
+			params: {
+				protocolVersion: '2024-11-05',
+				capabilities: {},
+				clientInfo: { name: 'TestClient', version: '1.0.0' },
+			},
+			id: 1,
+		})
+		const mcpHeaders = {
+			'Content-Type': 'application/json',
+			Accept: 'application/json, text/event-stream',
+		}
 
+		it('should return 401 when no auth is provided', async () => {
 			const request = new Request('http://example.com/mcp', {
 				method: 'POST',
-				body: JSON.stringify(initRequest),
-				headers: {
-					'Content-Type': 'application/json',
-					Accept: 'application/json, text/event-stream',
-				},
+				body: initBody,
+				headers: mcpHeaders,
 			})
 
 			const ctx = createExecutionContext()
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			expect(response.status).toBe(200)
-
-			// Should return a session ID for subsequent requests
-			const sessionId = response.headers.get('Mcp-Session-Id')
-			expect(sessionId).toBeTruthy()
-			expect(sessionId).toMatch(/^[0-9a-f-]{36}$/) // UUID format
+			expect(response.status).toBe(401)
 		})
 
-		it('should preserve existing session ID from header', async () => {
-			const existingSessionId = '12345678-1234-1234-1234-123456789012'
-			const initRequest = {
-				jsonrpc: '2.0',
-				method: 'initialize',
-				params: {
-					protocolVersion: '2024-11-05',
-					capabilities: {},
-					clientInfo: { name: 'TestClient', version: '1.0.0' },
-				},
-				id: 1,
-			}
-
+		it('should include WWW-Authenticate header pointing to OAuth metadata', async () => {
 			const request = new Request('http://example.com/mcp', {
 				method: 'POST',
-				body: JSON.stringify(initRequest),
-				headers: {
-					'Content-Type': 'application/json',
-					Accept: 'application/json, text/event-stream',
-					'Mcp-Session-Id': existingSessionId,
-				},
+				body: initBody,
+				headers: mcpHeaders,
 			})
 
 			const ctx = createExecutionContext()
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			expect(response.status).toBe(200)
-			expect(response.headers.get('Mcp-Session-Id')).toBe(existingSessionId)
+			expect(response.status).toBe(401)
+			const wwwAuth = response.headers.get('WWW-Authenticate')
+			expect(wwwAuth).not.toBeNull()
+			expect(wwwAuth).toContain('Bearer')
+			expect(wwwAuth).toContain('resource_metadata')
+			expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
 		})
 
-		it('should expose Mcp-Session-Id in Access-Control-Expose-Headers', async () => {
-			const initRequest = {
-				jsonrpc: '2.0',
-				method: 'initialize',
-				params: {
-					protocolVersion: '2024-11-05',
-					capabilities: {},
-					clientInfo: { name: 'TestClient', version: '1.0.0' },
-				},
-				id: 1,
-			}
-
+		it('should return 401 when Mcp-Session-Id header has no matching KV session', async () => {
+			// An unknown Mcp-Session-Id (not in KV) must fall through to OAuth → 401.
+			// The old behavior returned 200 by routing all requests through handleUnauthenticatedMcp.
 			const request = new Request('http://example.com/mcp', {
 				method: 'POST',
-				body: JSON.stringify(initRequest),
-				headers: {
-					'Content-Type': 'application/json',
-					Accept: 'application/json, text/event-stream',
-				},
+				body: initBody,
+				headers: { ...mcpHeaders, 'Mcp-Session-Id': 'unknown-session-not-in-kv' },
 			})
 
 			const ctx = createExecutionContext()
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			const exposeHeaders = response.headers.get('Access-Control-Expose-Headers')
-			expect(exposeHeaders).toContain('Mcp-Session-Id')
+			expect(response.status).toBe(401)
+			const wwwAuth = response.headers.get('WWW-Authenticate')
+			expect(wwwAuth).toContain('Bearer')
+		})
+
+		it('should not include a /login?session_id= URL in the response body', async () => {
+			const request = new Request('http://example.com/mcp', {
+				method: 'POST',
+				body: initBody,
+				headers: mcpHeaders,
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			const body = await response.clone().text()
+			expect(body).not.toContain('/login?session_id=')
 		})
 	})
 
@@ -134,6 +119,157 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			expect(response.status).toBe(401)
 			const result = (await response.json()) as { error: string }
 			expect(result.error).toBe('invalid_session')
+		})
+
+		it('should return 200 when session_id param has a valid KV session', async () => {
+			const sessionId = 'test-session-id-param-valid'
+			await env.MCP_SESSIONS.put(
+				`session:${sessionId}`,
+				JSON.stringify({
+					userId: 'testuser',
+					sessionKey: 'test-session-key',
+					username: 'testuser',
+					timestamp: Date.now(),
+					expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+					sessionId,
+				}),
+			)
+
+			const request = new Request(`http://example.com/mcp?session_id=${sessionId}`, {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'initialize',
+					params: {
+						protocolVersion: '2024-11-05',
+						capabilities: {},
+						clientInfo: { name: 'TestClient', version: '1.0.0' },
+					},
+					id: 1,
+				}),
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+				},
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(response.status).toBe(200)
+			expect(response.headers.get('Mcp-Session-Id')).toBe(sessionId)
+		})
+	})
+
+	describe('/mcp endpoint - Mcp-Session-Id header routing', () => {
+		const initBody = JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'initialize',
+			params: {
+				protocolVersion: '2024-11-05',
+				capabilities: {},
+				clientInfo: { name: 'TestClient', version: '1.0.0' },
+			},
+			id: 1,
+		})
+
+		it('should use session-based auth when Mcp-Session-Id header has a valid KV session', async () => {
+			const sessionId = 'test-mcp-header-valid-session'
+			await env.MCP_SESSIONS.put(
+				`session:${sessionId}`,
+				JSON.stringify({
+					userId: 'testuser',
+					sessionKey: 'test-session-key',
+					username: 'testuser',
+					timestamp: Date.now(),
+					expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+					sessionId,
+				}),
+			)
+
+			const request = new Request('http://example.com/mcp', {
+				method: 'POST',
+				body: initBody,
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					'Mcp-Session-Id': sessionId,
+				},
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(response.status).toBe(200)
+			expect(response.headers.get('Mcp-Session-Id')).toBe(sessionId)
+		})
+
+		it('should expose Mcp-Session-Id in Access-Control-Expose-Headers for session-based responses', async () => {
+			const sessionId = 'test-mcp-header-expose-session'
+			await env.MCP_SESSIONS.put(
+				`session:${sessionId}`,
+				JSON.stringify({
+					userId: 'testuser',
+					sessionKey: 'test-session-key',
+					username: 'testuser',
+					timestamp: Date.now(),
+					expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+					sessionId,
+				}),
+			)
+
+			const request = new Request('http://example.com/mcp', {
+				method: 'POST',
+				body: initBody,
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					'Mcp-Session-Id': sessionId,
+				},
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(response.status).toBe(200)
+			expect(response.headers.get('Access-Control-Expose-Headers')).toContain('Mcp-Session-Id')
+		})
+
+		it('should return 401 when Mcp-Session-Id header session is expired', async () => {
+			// handleSessionBasedMcp checks expiresAt and returns 401 with error: 'session_expired'
+			const sessionId = 'test-mcp-header-expired-session'
+			await env.MCP_SESSIONS.put(
+				`session:${sessionId}`,
+				JSON.stringify({
+					userId: 'testuser',
+					sessionKey: 'test-session-key',
+					username: 'testuser',
+					timestamp: Date.now() - 40 * 24 * 60 * 60 * 1000,
+					expiresAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
+					sessionId,
+				}),
+			)
+
+			const request = new Request('http://example.com/mcp', {
+				method: 'POST',
+				body: initBody,
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					'Mcp-Session-Id': sessionId,
+				},
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(response.status).toBe(401)
+			const result = (await response.json()) as { error: string }
+			expect(result.error).toBe('session_expired')
 		})
 	})
 
@@ -200,6 +336,54 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			const wwwAuth = response.headers.get('WWW-Authenticate')
 			expect(wwwAuth).toContain('Bearer')
 			expect(wwwAuth).toContain('resource_metadata')
+		})
+
+		it('should not return a /login?session_id= URL in OAuth path tool responses', async () => {
+			// Even with an invalid bearer token (401 expected),
+			// the OAuth path must never fall back to session-based auth messages.
+			const request = new Request('http://example.com/mcp', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'tools/call',
+					params: { name: 'get_recent_tracks', arguments: {} },
+					id: 1,
+				}),
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					Authorization: 'Bearer invalid-token',
+				},
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			const body = await response.clone().text()
+			expect(body).not.toContain('/login?session_id=')
+		})
+	})
+
+	describe('regression: /mcp never returns copy-paste login URL', () => {
+		it('unauthenticated POST /mcp should return 401, not 200 with login URL', async () => {
+			const req = new Request('https://lastfm-mcp.com/mcp', { method: 'POST' })
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
+			expect(res.status).toBe(401)
+			const body = await res.text()
+			expect(body).not.toContain('/login?session_id=')
+		})
+
+		it('unauthenticated POST /mcp should have WWW-Authenticate, not login URL in body', async () => {
+			const req = new Request('https://lastfm-mcp.com/mcp', { method: 'POST' })
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
+			expect(res.headers.get('WWW-Authenticate')).toBeTruthy()
+			const body = await res.text()
+			expect(body).not.toContain('/login?session_id=')
 		})
 	})
 

--- a/test/index-oauth.test.ts
+++ b/test/index-oauth.test.ts
@@ -235,7 +235,7 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			await waitOnExecutionContext(ctx)
 
 			expect(response.status).toBe(200)
-			expect(response.headers.get('Access-Control-Expose-Headers')).toContain('Mcp-Session-Id')
+			expect(response.headers.get('Access-Control-Expose-Headers')?.toLowerCase()).toContain('mcp-session-id')
 		})
 
 		it('should return 401 when Mcp-Session-Id header session is expired', async () => {

--- a/test/index-oauth.test.ts
+++ b/test/index-oauth.test.ts
@@ -1,15 +1,16 @@
 /**
  * Tests for the OAuth entry point (src/index-oauth.ts)
  *
- * Tests unauthenticated MCP access, session-based auth, and OAuth routing.
+ * Tests that unauthenticated /mcp requests trigger the OAuth flow (401 + WWW-Authenticate),
+ * session-based auth via session_id param, and OAuth Bearer token routing.
  */
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { describe, it, expect } from 'vitest'
 import worker from '../src/index-oauth'
 
 describe('Last.fm MCP Server (OAuth Entry Point)', () => {
-	describe('/mcp endpoint - unauthenticated access', () => {
-		it('should handle initialize request without authentication', async () => {
+	describe('/mcp endpoint - unauthenticated access triggers OAuth flow', () => {
+		it('should return 401 with WWW-Authenticate for requests without auth', async () => {
 			const initRequest = {
 				jsonrpc: '2.0',
 				method: 'initialize',
@@ -34,16 +35,14 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			expect(response.status).toBe(200)
-
-			// Should return a session ID for subsequent requests
-			const sessionId = response.headers.get('Mcp-Session-Id')
-			expect(sessionId).toBeTruthy()
-			expect(sessionId).toMatch(/^[0-9a-f-]{36}$/) // UUID format
+			// Must return 401 so mcp-remote / Claude Code / OpenCode trigger the OAuth flow
+			expect(response.status).toBe(401)
+			const wwwAuth = response.headers.get('WWW-Authenticate')
+			expect(wwwAuth).toContain('Bearer')
+			expect(wwwAuth).toContain('resource_metadata')
 		})
 
-		it('should preserve existing session ID from header', async () => {
-			const existingSessionId = '12345678-1234-1234-1234-123456789012'
+		it('should return 401 even when Mcp-Session-Id header is present but no Bearer token', async () => {
 			const initRequest = {
 				jsonrpc: '2.0',
 				method: 'initialize',
@@ -61,7 +60,7 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 				headers: {
 					'Content-Type': 'application/json',
 					Accept: 'application/json, text/event-stream',
-					'Mcp-Session-Id': existingSessionId,
+					'Mcp-Session-Id': '12345678-1234-1234-1234-123456789012',
 				},
 			})
 
@@ -69,37 +68,9 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			expect(response.status).toBe(200)
-			expect(response.headers.get('Mcp-Session-Id')).toBe(existingSessionId)
-		})
-
-		it('should expose Mcp-Session-Id in Access-Control-Expose-Headers', async () => {
-			const initRequest = {
-				jsonrpc: '2.0',
-				method: 'initialize',
-				params: {
-					protocolVersion: '2024-11-05',
-					capabilities: {},
-					clientInfo: { name: 'TestClient', version: '1.0.0' },
-				},
-				id: 1,
-			}
-
-			const request = new Request('http://example.com/mcp', {
-				method: 'POST',
-				body: JSON.stringify(initRequest),
-				headers: {
-					'Content-Type': 'application/json',
-					Accept: 'application/json, text/event-stream',
-				},
-			})
-
-			const ctx = createExecutionContext()
-			const response = await worker.fetch(request, env, ctx)
-			await waitOnExecutionContext(ctx)
-
-			const exposeHeaders = response.headers.get('Access-Control-Expose-Headers')
-			expect(exposeHeaders).toContain('Mcp-Session-Id')
+			expect(response.status).toBe(401)
+			const wwwAuth = response.headers.get('WWW-Authenticate')
+			expect(wwwAuth).toContain('Bearer')
 		})
 	})
 

--- a/test/index-oauth.test.ts
+++ b/test/index-oauth.test.ts
@@ -49,14 +49,13 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			expect(response.status).toBe(401)
 			const wwwAuth = response.headers.get('WWW-Authenticate')
 			expect(wwwAuth).not.toBeNull()
-			expect(wwwAuth).toContain('Bearer')
-			expect(wwwAuth).toContain('resource_metadata')
-			expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
+			expect(wwwAuth).toContain(
+				'Bearer resource_metadata="http://example.com/.well-known/oauth-protected-resource"',
+			)
 		})
 
 		it('should return 401 when Mcp-Session-Id header has no matching KV session', async () => {
 			// An unknown Mcp-Session-Id (not in KV) must fall through to OAuth → 401.
-			// The old behavior returned 200 by routing all requests through handleUnauthenticatedMcp.
 			const request = new Request('http://example.com/mcp', {
 				method: 'POST',
 				body: initBody,
@@ -69,7 +68,9 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 
 			expect(response.status).toBe(401)
 			const wwwAuth = response.headers.get('WWW-Authenticate')
-			expect(wwwAuth).toContain('Bearer')
+			expect(wwwAuth).toContain(
+				'Bearer resource_metadata="http://example.com/.well-known/oauth-protected-resource"',
+			)
 		})
 
 		it('should not include a /login?session_id= URL in the response body', async () => {
@@ -334,9 +335,12 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 
 			expect(response.status).toBe(401)
 			const wwwAuth = response.headers.get('WWW-Authenticate')
-			expect(wwwAuth).toContain('Bearer')
-			expect(wwwAuth).toContain('resource_metadata')
+			expect(wwwAuth).toContain(
+				'Bearer resource_metadata="http://example.com/.well-known/oauth-protected-resource"',
+			)
 		})
+
+		it.todo('should return 200 when valid bearer token provided — covered by oauth-roundtrip integration test')
 
 		it('should not return a /login?session_id= URL in OAuth path tool responses', async () => {
 			// Even with an invalid bearer token (401 expected),

--- a/test/index-oauth.test.ts
+++ b/test/index-oauth.test.ts
@@ -1,16 +1,15 @@
 /**
  * Tests for the OAuth entry point (src/index-oauth.ts)
  *
- * Tests that unauthenticated /mcp requests trigger the OAuth flow (401 + WWW-Authenticate),
- * session-based auth via session_id param, and OAuth Bearer token routing.
+ * Tests unauthenticated MCP access, session-based auth, and OAuth routing.
  */
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
 import { describe, it, expect } from 'vitest'
 import worker from '../src/index-oauth'
 
 describe('Last.fm MCP Server (OAuth Entry Point)', () => {
-	describe('/mcp endpoint - unauthenticated access triggers OAuth flow', () => {
-		it('should return 401 with WWW-Authenticate for requests without auth', async () => {
+	describe('/mcp endpoint - unauthenticated access', () => {
+		it('should handle initialize request without authentication', async () => {
 			const initRequest = {
 				jsonrpc: '2.0',
 				method: 'initialize',
@@ -35,14 +34,16 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			// Must return 401 so mcp-remote / Claude Code / OpenCode trigger the OAuth flow
-			expect(response.status).toBe(401)
-			const wwwAuth = response.headers.get('WWW-Authenticate')
-			expect(wwwAuth).toContain('Bearer')
-			expect(wwwAuth).toContain('resource_metadata')
+			expect(response.status).toBe(200)
+
+			// Should return a session ID for subsequent requests
+			const sessionId = response.headers.get('Mcp-Session-Id')
+			expect(sessionId).toBeTruthy()
+			expect(sessionId).toMatch(/^[0-9a-f-]{36}$/) // UUID format
 		})
 
-		it('should return 401 even when Mcp-Session-Id header is present but no Bearer token', async () => {
+		it('should preserve existing session ID from header', async () => {
+			const existingSessionId = '12345678-1234-1234-1234-123456789012'
 			const initRequest = {
 				jsonrpc: '2.0',
 				method: 'initialize',
@@ -60,7 +61,7 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 				headers: {
 					'Content-Type': 'application/json',
 					Accept: 'application/json, text/event-stream',
-					'Mcp-Session-Id': '12345678-1234-1234-1234-123456789012',
+					'Mcp-Session-Id': existingSessionId,
 				},
 			})
 
@@ -68,9 +69,37 @@ describe('Last.fm MCP Server (OAuth Entry Point)', () => {
 			const response = await worker.fetch(request, env, ctx)
 			await waitOnExecutionContext(ctx)
 
-			expect(response.status).toBe(401)
-			const wwwAuth = response.headers.get('WWW-Authenticate')
-			expect(wwwAuth).toContain('Bearer')
+			expect(response.status).toBe(200)
+			expect(response.headers.get('Mcp-Session-Id')).toBe(existingSessionId)
+		})
+
+		it('should expose Mcp-Session-Id in Access-Control-Expose-Headers', async () => {
+			const initRequest = {
+				jsonrpc: '2.0',
+				method: 'initialize',
+				params: {
+					protocolVersion: '2024-11-05',
+					capabilities: {},
+					clientInfo: { name: 'TestClient', version: '1.0.0' },
+				},
+				id: 1,
+			}
+
+			const request = new Request('http://example.com/mcp', {
+				method: 'POST',
+				body: JSON.stringify(initRequest),
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+				},
+			})
+
+			const ctx = createExecutionContext()
+			const response = await worker.fetch(request, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			const exposeHeaders = response.headers.get('Access-Control-Expose-Headers')
+			expect(exposeHeaders).toContain('Mcp-Session-Id')
 		})
 	})
 

--- a/test/oauth-discovery.test.ts
+++ b/test/oauth-discovery.test.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Tests for OAuth 2.1 discovery endpoints required by MCP spec.
+// ABOUTME: Verifies /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server return correct metadata.
+import { describe, it, expect } from 'vitest'
+import { env } from 'cloudflare:test'
+import worker from '../src/index-oauth'
+
+const BASE_URL = 'https://lastfm-mcp.com'
+
+describe('OAuth discovery endpoints', () => {
+	describe('/.well-known/oauth-protected-resource', () => {
+		it('should return 200 with correct content type', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-protected-resource`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			expect(res.status).toBe(200)
+			expect(res.headers.get('content-type')).toContain('application/json')
+		})
+
+		it('should include resource field matching base URL', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-protected-resource`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(body.resource).toBe(BASE_URL)
+		})
+
+		it('should include authorization_servers array with base URL', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-protected-resource`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(Array.isArray(body.authorization_servers)).toBe(true)
+			expect(body.authorization_servers).toContain(BASE_URL)
+		})
+
+		it('should include bearer_methods_supported with header', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-protected-resource`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(Array.isArray(body.bearer_methods_supported)).toBe(true)
+			expect(body.bearer_methods_supported).toContain('header')
+		})
+	})
+
+	describe('/.well-known/oauth-authorization-server', () => {
+		it('should return 200 with correct content type', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			expect(res.status).toBe(200)
+			expect(res.headers.get('content-type')).toContain('application/json')
+		})
+
+		it('should include all required MCP OAuth fields', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(body.issuer).toBeDefined()
+			expect(body.authorization_endpoint).toBeDefined()
+			expect(body.token_endpoint).toBeDefined()
+		})
+
+		it('should support authorization_code grant type', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(Array.isArray(body.grant_types_supported)).toBe(true)
+			expect(body.grant_types_supported).toContain('authorization_code')
+		})
+
+		it('should support code response type', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(Array.isArray(body.response_types_supported)).toBe(true)
+			expect(body.response_types_supported).toContain('code')
+		})
+
+		it('should support S256 PKCE code challenge method', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const res = await worker.fetch(req, env, {} as ExecutionContext)
+			const body = await res.json() as Record<string, unknown>
+			expect(Array.isArray(body.code_challenge_methods_supported)).toBe(true)
+			expect(body.code_challenge_methods_supported).toContain('S256')
+		})
+	})
+})

--- a/test/oauth-roundtrip.test.ts
+++ b/test/oauth-roundtrip.test.ts
@@ -54,11 +54,7 @@ async function computeS256Challenge(verifier: string): Promise<string> {
 
 describe('OAuth round-trip integration', () => {
 	describe('Step 1: POST /mcp without auth returns 401', () => {
-		// These two tests document the routing bug: handleUnauthenticatedMcp intercepts
-		// unauthenticated /mcp requests and returns 200 instead of letting the OAuth
-		// provider return 401. They are marked it.fails to confirm the current behaviour
-		// and will be converted to regular `it` tests once the routing fix is applied.
-		it.fails('should return 401 when no auth is provided [fails before routing fix]', async () => {
+		it('should return 401 when no auth is provided', async () => {
 			const req = new Request(`${BASE_URL}/mcp`, {
 				method: 'POST',
 				body: MCP_INIT_BODY,
@@ -71,26 +67,23 @@ describe('OAuth round-trip integration', () => {
 			expect(res.status).toBe(401)
 		})
 
-		it.fails(
-			'should include WWW-Authenticate header pointing to OAuth metadata [fails before routing fix]',
-			async () => {
-				const req = new Request(`${BASE_URL}/mcp`, {
-					method: 'POST',
-					body: MCP_INIT_BODY,
-					headers: MCP_HEADERS,
-				})
-				const ctx = createExecutionContext()
-				const res = await worker.fetch(req, env, ctx)
-				await waitOnExecutionContext(ctx)
+		it('should include WWW-Authenticate header pointing to OAuth metadata', async () => {
+			const req = new Request(`${BASE_URL}/mcp`, {
+				method: 'POST',
+				body: MCP_INIT_BODY,
+				headers: MCP_HEADERS,
+			})
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
 
-				expect(res.status).toBe(401)
-				const wwwAuth = res.headers.get('WWW-Authenticate')
-				expect(wwwAuth).not.toBeNull()
-				expect(wwwAuth).toContain('Bearer')
-				expect(wwwAuth).toContain('resource_metadata')
-				expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
-			},
-		)
+			expect(res.status).toBe(401)
+			const wwwAuth = res.headers.get('WWW-Authenticate')
+			expect(wwwAuth).not.toBeNull()
+			expect(wwwAuth).toContain('Bearer')
+			expect(wwwAuth).toContain('resource_metadata')
+			expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
+		})
 	})
 
 	describe('Step 2: GET /.well-known/oauth-protected-resource', () => {

--- a/test/oauth-roundtrip.test.ts
+++ b/test/oauth-roundtrip.test.ts
@@ -1,0 +1,306 @@
+// ABOUTME: Integration test for the full OAuth 2.1 round-trip flow.
+// ABOUTME: Tests unauthenticated MCP returns 401, discovery endpoints work, and OAuth authorize redirect happens.
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import worker from '../src/index-oauth'
+
+// Mock Last.fm auth to avoid real HTTP calls during the callback simulation.
+// getAuthUrl passes the callbackUrl through so the real stateToken is preserved in the URL.
+// getSessionKey avoids the actual Last.fm API call for the token exchange.
+vi.mock('../src/auth/lastfm', () => ({
+	LastfmAuth: vi.fn().mockImplementation(() => ({
+		getAuthUrl: vi.fn().mockImplementation((callbackUrl?: string) => {
+			const params = new URLSearchParams({ api_key: 'test-key' })
+			if (callbackUrl) params.set('cb', callbackUrl)
+			return `https://www.last.fm/api/auth/?${params.toString()}`
+		}),
+		getSessionKey: vi.fn().mockResolvedValue({
+			sessionKey: 'mock-session-key',
+			username: 'testuser',
+		}),
+	})),
+}))
+
+const BASE_URL = 'https://lastfm-mcp.com'
+
+const MCP_INIT_BODY = JSON.stringify({
+	jsonrpc: '2.0',
+	method: 'initialize',
+	params: {
+		protocolVersion: '2024-11-05',
+		capabilities: {},
+		clientInfo: { name: 'TestClient', version: '1.0.0' },
+	},
+	id: 1,
+})
+
+const MCP_HEADERS = {
+	'Content-Type': 'application/json',
+	Accept: 'application/json, text/event-stream',
+}
+
+/**
+ * Compute PKCE S256 code challenge from a code verifier
+ */
+async function computeS256Challenge(verifier: string): Promise<string> {
+	const encoder = new TextEncoder()
+	const data = encoder.encode(verifier)
+	const digest = await crypto.subtle.digest('SHA-256', data)
+	return btoa(String.fromCharCode(...new Uint8Array(digest)))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=/g, '')
+}
+
+describe('OAuth round-trip integration', () => {
+	describe('Step 1: POST /mcp without auth returns 401', () => {
+		// These two tests document the routing bug: handleUnauthenticatedMcp intercepts
+		// unauthenticated /mcp requests and returns 200 instead of letting the OAuth
+		// provider return 401. They are marked it.fails to confirm the current behaviour
+		// and will be converted to regular `it` tests once the routing fix is applied.
+		it.fails('should return 401 when no auth is provided [fails before routing fix]', async () => {
+			const req = new Request(`${BASE_URL}/mcp`, {
+				method: 'POST',
+				body: MCP_INIT_BODY,
+				headers: MCP_HEADERS,
+			})
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(res.status).toBe(401)
+		})
+
+		it.fails(
+			'should include WWW-Authenticate header pointing to OAuth metadata [fails before routing fix]',
+			async () => {
+				const req = new Request(`${BASE_URL}/mcp`, {
+					method: 'POST',
+					body: MCP_INIT_BODY,
+					headers: MCP_HEADERS,
+				})
+				const ctx = createExecutionContext()
+				const res = await worker.fetch(req, env, ctx)
+				await waitOnExecutionContext(ctx)
+
+				expect(res.status).toBe(401)
+				const wwwAuth = res.headers.get('WWW-Authenticate')
+				expect(wwwAuth).not.toBeNull()
+				expect(wwwAuth).toContain('Bearer')
+				expect(wwwAuth).toContain('resource_metadata')
+				expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
+			},
+		)
+	})
+
+	describe('Step 2: GET /.well-known/oauth-protected-resource', () => {
+		it('should return valid JSON with authorization_servers', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-protected-resource`)
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(res.status).toBe(200)
+			expect(res.headers.get('content-type')).toContain('application/json')
+
+			const body = (await res.json()) as Record<string, unknown>
+			expect(body.resource).toBe(BASE_URL)
+			expect(Array.isArray(body.authorization_servers)).toBe(true)
+			expect(body.authorization_servers).toContain(BASE_URL)
+			expect(Array.isArray(body.bearer_methods_supported)).toBe(true)
+			expect(body.bearer_methods_supported).toContain('header')
+		})
+	})
+
+	describe('Step 3: GET /.well-known/oauth-authorization-server', () => {
+		it('should return valid authorization server metadata', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			expect(res.status).toBe(200)
+			expect(res.headers.get('content-type')).toContain('application/json')
+
+			const body = (await res.json()) as Record<string, unknown>
+			expect(body.issuer).toBeDefined()
+			expect(body.authorization_endpoint).toBeDefined()
+			expect(body.token_endpoint).toBeDefined()
+		})
+
+		it('should support PKCE with S256 and authorization_code grant', async () => {
+			const req = new Request(`${BASE_URL}/.well-known/oauth-authorization-server`)
+			const ctx = createExecutionContext()
+			const res = await worker.fetch(req, env, ctx)
+			await waitOnExecutionContext(ctx)
+
+			const body = (await res.json()) as Record<string, unknown>
+			expect(Array.isArray(body.grant_types_supported)).toBe(true)
+			expect(body.grant_types_supported).toContain('authorization_code')
+			expect(Array.isArray(body.code_challenge_methods_supported)).toBe(true)
+			expect(body.code_challenge_methods_supported).toContain('S256')
+		})
+	})
+
+	describe('Step 4: Dynamic client registration + GET /authorize', () => {
+		it('should register a client and redirect to Last.fm for authorization', async () => {
+			// Register a dynamic OAuth client
+			const registrationRes = await worker.fetch(
+				new Request(`${BASE_URL}/oauth/register`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						client_name: 'Test MCP Client',
+						redirect_uris: ['http://localhost:3000/callback'],
+						grant_types: ['authorization_code'],
+						response_types: ['code'],
+						token_endpoint_auth_method: 'none',
+					}),
+				}),
+				env,
+				{} as ExecutionContext,
+			)
+
+			expect(registrationRes.status).toBe(201)
+			const { client_id } = (await registrationRes.json()) as { client_id: string }
+			expect(client_id).toBeTruthy()
+
+			// Build PKCE challenge
+			const codeVerifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+			const codeChallenge = await computeS256Challenge(codeVerifier)
+			const state = crypto.randomUUID()
+
+			// Hit the authorize endpoint
+			const authorizeUrl = new URL(`${BASE_URL}/authorize`)
+			authorizeUrl.searchParams.set('client_id', client_id)
+			authorizeUrl.searchParams.set('redirect_uri', 'http://localhost:3000/callback')
+			authorizeUrl.searchParams.set('code_challenge', codeChallenge)
+			authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+			authorizeUrl.searchParams.set('response_type', 'code')
+			authorizeUrl.searchParams.set('state', state)
+
+			const authorizeRes = await worker.fetch(new Request(authorizeUrl.toString()), env, {} as ExecutionContext)
+
+			// The authorize endpoint should redirect to Last.fm
+			expect(authorizeRes.status).toBe(302)
+			const location = authorizeRes.headers.get('Location') ?? ''
+			expect(location).toContain('last.fm')
+		})
+	})
+
+	describe('Steps 5-7: Last.fm callback → token exchange → authenticated MCP (E2E only)', () => {
+		it('completes Last.fm callback → code → token → authenticated MCP request', async () => {
+			// Step 4a: Register client
+			const registrationRes = await worker.fetch(
+				new Request(`${BASE_URL}/oauth/register`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						client_name: 'Round-trip Test Client',
+						redirect_uris: ['http://localhost:3000/callback'],
+						grant_types: ['authorization_code'],
+						response_types: ['code'],
+						token_endpoint_auth_method: 'none',
+					}),
+				}),
+				env,
+				{} as ExecutionContext,
+			)
+			expect(registrationRes.status).toBe(201)
+			const { client_id } = (await registrationRes.json()) as { client_id: string }
+
+			// Step 4b: Initiate authorize to get the state token stored in KV
+			const codeVerifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+			const codeChallenge = await computeS256Challenge(codeVerifier)
+			const oauthState = crypto.randomUUID()
+
+			const authorizeUrl = new URL(`${BASE_URL}/authorize`)
+			authorizeUrl.searchParams.set('client_id', client_id)
+			authorizeUrl.searchParams.set('redirect_uri', 'http://localhost:3000/callback')
+			authorizeUrl.searchParams.set('code_challenge', codeChallenge)
+			authorizeUrl.searchParams.set('code_challenge_method', 'S256')
+			authorizeUrl.searchParams.set('response_type', 'code')
+			authorizeUrl.searchParams.set('state', oauthState)
+
+			const authorizeRes = await worker.fetch(new Request(authorizeUrl.toString()), env, {} as ExecutionContext)
+			expect(authorizeRes.status).toBe(302)
+
+			// Step 4c: Extract the Last.fm redirect URL and parse out the lastfm_state
+			// The Location is the Last.fm auth URL with a `cb` param containing the callback URL.
+			// That callback URL has the stateToken we stored in KV.
+			const lastfmRedirect = authorizeRes.headers.get('Location') ?? ''
+			expect(lastfmRedirect).toContain('last.fm')
+
+			const lastfmRedirectUrl = new URL(lastfmRedirect)
+			const cbParam = lastfmRedirectUrl.searchParams.get('cb') ?? ''
+			expect(cbParam).toContain('/lastfm-callback')
+
+			const cbUrl = new URL(cbParam)
+			const stateToken = cbUrl.searchParams.get('state') ?? ''
+			expect(stateToken).toBeTruthy()
+
+			// Step 5: Simulate Last.fm redirecting back with a token
+			const simulatedLastfmToken = 'simulated-lastfm-token'
+			const callbackUrl = new URL(`${BASE_URL}/lastfm-callback`)
+			callbackUrl.searchParams.set('token', simulatedLastfmToken)
+			callbackUrl.searchParams.set('state', stateToken)
+
+			const callbackRes = await worker.fetch(new Request(callbackUrl.toString()), env, {} as ExecutionContext)
+
+			// The callback should redirect to the MCP client's redirect_uri with an authorization code
+			expect(callbackRes.status).toBe(302)
+			const codeRedirect = callbackRes.headers.get('Location') ?? ''
+			expect(codeRedirect).toContain('localhost:3000/callback')
+
+			const codeRedirectUrl = new URL(codeRedirect)
+			const authCode = codeRedirectUrl.searchParams.get('code') ?? ''
+			expect(authCode).toBeTruthy()
+
+			// Step 6: Exchange the authorization code for an access token
+			const tokenRes = await worker.fetch(
+				new Request(`${BASE_URL}/oauth/token`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: new URLSearchParams({
+						grant_type: 'authorization_code',
+						code: authCode,
+						client_id,
+						redirect_uri: 'http://localhost:3000/callback',
+						code_verifier: codeVerifier,
+					}).toString(),
+				}),
+				env,
+				{} as ExecutionContext,
+			)
+
+			expect(tokenRes.status).toBe(200)
+			const tokenBody = (await tokenRes.json()) as { access_token?: string; token_type?: string }
+			expect(tokenBody.access_token).toBeTruthy()
+			// OAuth spec allows lowercase token_type; both 'bearer' and 'Bearer' are valid
+			expect(tokenBody.token_type?.toLowerCase()).toBe('bearer')
+
+			const accessToken = tokenBody.access_token!
+
+			// Step 7: Use the access token to make an authenticated /mcp request
+			// NOTE: This step currently FAILS (returns 200 via handleUnauthenticatedMcp even without
+			// a token) but will return 200 correctly via the OAuth apiHandler after the routing fix.
+			// We verify that a valid Bearer token is accepted (not rejected as invalid_token).
+			const mcpRes = await worker.fetch(
+				new Request(`${BASE_URL}/mcp`, {
+					method: 'POST',
+					body: MCP_INIT_BODY,
+					headers: {
+						...MCP_HEADERS,
+						Authorization: `Bearer ${accessToken}`,
+					},
+				}),
+				env,
+				{} as ExecutionContext,
+			)
+
+			// A valid token should not be rejected as invalid_token — either 200 (success)
+			// or 401 with a different error is unexpected
+			expect(mcpRes.status).toBe(200)
+		})
+	})
+})

--- a/test/oauth-roundtrip.test.ts
+++ b/test/oauth-roundtrip.test.ts
@@ -80,9 +80,9 @@ describe('OAuth round-trip integration', () => {
 			expect(res.status).toBe(401)
 			const wwwAuth = res.headers.get('WWW-Authenticate')
 			expect(wwwAuth).not.toBeNull()
-			expect(wwwAuth).toContain('Bearer')
-			expect(wwwAuth).toContain('resource_metadata')
-			expect(wwwAuth).toContain('/.well-known/oauth-protected-resource')
+			expect(wwwAuth).toContain(
+				`Bearer resource_metadata="${BASE_URL}/.well-known/oauth-protected-resource"`,
+			)
 		})
 	})
 
@@ -274,10 +274,8 @@ describe('OAuth round-trip integration', () => {
 
 			const accessToken = tokenBody.access_token!
 
-			// Step 7: Use the access token to make an authenticated /mcp request
-			// NOTE: This step currently FAILS (returns 200 via handleUnauthenticatedMcp even without
-			// a token) but will return 200 correctly via the OAuth apiHandler after the routing fix.
-			// We verify that a valid Bearer token is accepted (not rejected as invalid_token).
+			// Step 7: Use the access token to make an authenticated /mcp request.
+			// A valid Bearer token must be accepted by the OAuth apiHandler and return 200.
 			const mcpRes = await worker.fetch(
 				new Request(`${BASE_URL}/mcp`, {
 					method: 'POST',

--- a/test/stubs/ajv-formats-stub.js
+++ b/test/stubs/ajv-formats-stub.js
@@ -1,0 +1,17 @@
+// ABOUTME: Test stub for the ajv-formats package used alongside ajv.
+// ABOUTME: Replaces the CJS ajv-formats package that cannot run in workerd's ESM-only runtime.
+
+/**
+ * Minimal ajv-formats stub for use in Cloudflare Workers test environment.
+ *
+ * The real ajv-formats package adds format validators (date, email, etc.) to an
+ * Ajv instance. Since we stub out Ajv itself, this stub is a no-op that accepts
+ * and ignores any Ajv instance passed to it.
+ */
+function addFormats(_ajv, _options) {
+	// No-op: format validation not needed in tests
+}
+
+addFormats.formats = {}
+
+export default addFormats

--- a/test/stubs/ajv-stub.js
+++ b/test/stubs/ajv-stub.js
@@ -1,0 +1,34 @@
+// ABOUTME: Test stub for the ajv JSON Schema validator package.
+// ABOUTME: Replaces the CJS ajv package that cannot run in workerd's ESM-only runtime.
+
+/**
+ * Minimal Ajv stub for use in Cloudflare Workers test environment.
+ *
+ * The real ajv package is CJS-only and uses code generation (new Function/eval)
+ * which is not available in workerd. This stub provides the interface expected
+ * by @modelcontextprotocol/sdk's AjvJsonSchemaValidator so the server can be
+ * loaded in tests. Validation always passes (returns valid: true) since tests
+ * focus on routing and auth logic, not schema validation.
+ */
+export class Ajv {
+	constructor(_options) {
+		// No-op: options are irrelevant for the stub
+	}
+
+	compile(_schema) {
+		// Return a validator function that always passes
+		const validate = (_data) => true
+		validate.errors = null
+		return validate
+	}
+
+	getSchema(_id) {
+		return undefined
+	}
+
+	errorsText(_errors) {
+		return 'validation error'
+	}
+}
+
+export default Ajv

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,7 +1,29 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineWorkersConfig({
+	resolve: {
+		// Redirect 'ajv' imports to an ESM-compatible stub that avoids loading the
+		// nested CJS ajv package inside @modelcontextprotocol/sdk. workerd cannot
+		// execute that CJS module, which causes "Unexpected token ':'" errors.
+		// The MCP SDK uses ajv only for JSON Schema validation; tools validation
+		// still works via zod schemas, so the no-op stub is safe for tests.
+		alias: {
+			ajv: path.resolve(__dirname, 'test/stubs/ajv-stub.js'),
+			'ajv-formats': path.resolve(__dirname, 'test/stubs/ajv-formats-stub.js'),
+		},
+	},
 	test: {
+		exclude: [
+			// Default vitest excludes
+			'**/node_modules/**',
+			'**/dist/**',
+			// Exclude worktrees to prevent duplicate test discovery when running from repo root
+			'**/.worktrees/**',
+		],
 		poolOptions: {
 			workers: {
 				wrangler: { configPath: './wrangler.toml' },


### PR DESCRIPTION
## Summary

- Removes `handleUnauthenticatedMcp()` which was bypassing the OAuth provider and showing copy-paste login URLs instead of triggering the browser OAuth flow
- Adds `Mcp-Session-Id` header + KV lookup before falling through to OAuth provider, preserving existing sessions from the manual `/login` path
- Unauthenticated `POST /mcp` now returns `401 + WWW-Authenticate: Bearer resource_metadata=...` so MCP clients (Claude Code, Claude Desktop, opencode) open the browser automatically
- Fixes CJS `ajv` compatibility error in Cloudflare Workers test pool (adds ESM stubs)

## Test Plan

- [ ] Unit tests: `npx vitest run test/index-oauth.test.ts` — 22 tests, verify unauthenticated requests return 401
- [ ] Discovery tests: `npx vitest run test/oauth-discovery.test.ts` — 9 tests, verify OAuth metadata endpoints
- [ ] Round-trip test: `npx vitest run test/oauth-roundtrip.test.ts` — full 7-step OAuth flow
- [ ] Manual: connect MCP Inspector (`npx @modelcontextprotocol/inspector`) to `http://localhost:8787/mcp` and confirm OAuth browser prompt appears instead of copy-paste URL
- [ ] Manual: verify existing session via `session_id` param or `Mcp-Session-Id` header continues to work

🤖 Generated with [Claude Code](https://claude.ai/claude-code)