### PR TITLE
Polish: dead throttle, dynamic tool list, album.artist rendering

### DIFF
--- a/src/auth/lastfm.ts
+++ b/src/auth/lastfm.ts
@@ -33,7 +33,6 @@ export class LastfmAuth {
 	private sharedSecret: string
 	private baseUrl = 'https://ws.audioscrobbler.com/2.0/'
 	private authUrl = 'https://www.last.fm/api/auth/'
-	private lastRequestTime = 0
 
 	// Last.fm specific retry configuration
 	private readonly lastfmRetryOptions: RetryOptions = {
@@ -42,21 +41,6 @@ export class LastfmAuth {
 		maxDelayMs: 15000,
 		backoffMultiplier: 2,
 		jitterFactor: 0.1,
-	}
-
-	// Minimum delay between requests to respect rate limits (~5 req/sec)
-	private readonly REQUEST_DELAY_MS = 250 // 250ms to stay under 5 req/sec
-
-	/**
-	 * Add delay between requests to respect Last.fm rate limits
-	 */
-	private async throttleRequest(): Promise<void> {
-		const timeSinceLastRequest = Date.now() - this.lastRequestTime
-		if (timeSinceLastRequest < this.REQUEST_DELAY_MS) {
-			const delayNeeded = this.REQUEST_DELAY_MS - timeSinceLastRequest
-			await new Promise((resolve) => setTimeout(resolve, delayNeeded))
-		}
-		this.lastRequestTime = Date.now()
 	}
 
 	constructor(apiKey: string, sharedSecret: string) {
@@ -123,7 +107,6 @@ export class LastfmAuth {
 		})
 
 		try {
-			await this.throttleRequest()
 			const response = await fetchWithRetry(
 				this.baseUrl,
 				{
@@ -194,7 +177,6 @@ export class LastfmAuth {
 			const params = await this.createSignedParams('user.getInfo', sessionKey)
 			const formData = new URLSearchParams(params)
 
-			await this.throttleRequest()
 			const response = await fetchWithRetry(
 				this.baseUrl,
 				{

--- a/src/clients/lastfm.ts
+++ b/src/clients/lastfm.ts
@@ -359,7 +359,6 @@ type LastfmApiResponse<T> = T | LastfmError
 export class LastfmClient {
 	private apiKey: string
 	private baseUrl = 'https://ws.audioscrobbler.com/2.0/'
-	private lastRequestTime = 0
 
 	// Last.fm specific retry configuration
 	private readonly lastfmRetryOptions: RetryOptions = {
@@ -370,23 +369,8 @@ export class LastfmClient {
 		jitterFactor: 0.1,
 	}
 
-	// Minimum delay between requests to respect rate limits (~5 req/sec)
-	private readonly REQUEST_DELAY_MS = 250 // 250ms to stay under 5 req/sec
-
 	constructor(apiKey: string) {
 		this.apiKey = apiKey
-	}
-
-	/**
-	 * Add delay between requests to respect Last.fm rate limits
-	 */
-	private async throttleRequest(): Promise<void> {
-		const timeSinceLastRequest = Date.now() - this.lastRequestTime
-		if (timeSinceLastRequest < this.REQUEST_DELAY_MS) {
-			const delayNeeded = this.REQUEST_DELAY_MS - timeSinceLastRequest
-			await new Promise((resolve) => setTimeout(resolve, delayNeeded))
-		}
-		this.lastRequestTime = Date.now()
 	}
 
 	/**
@@ -398,8 +382,6 @@ export class LastfmClient {
 			format: 'json',
 			...params,
 		})
-
-		await this.throttleRequest()
 
 		const response = await fetchWithRetry(
 			`${this.baseUrl}?${searchParams.toString()}`,

--- a/src/mcp/tools/authenticated.ts
+++ b/src/mcp/tools/authenticated.ts
@@ -5,7 +5,9 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
 import { CachedLastfmClient } from '../../clients/cachedLastfm'
+import { AUTHENTICATED_TOOL_CATALOG, PUBLIC_TOOL_CATALOG, renderToolList } from './catalog'
 import { toolError } from './error-handler'
+import { formatArtist } from './formatters'
 import { formatTimestamp, getDayBoundsUTC } from '../../utils/dateFormat'
 
 /**
@@ -68,14 +70,7 @@ You are not currently authenticated with Last.fm. To access your personal listen
 • Analyze your listening patterns and statistics
 
 **Available without authentication:**
-• \`ping\` - Test server connectivity
-• \`server_info\` - Get server information
-• \`lastfm_auth_status\` - Check authentication status (this tool)
-• \`get_track_info\` - Get basic track information
-• \`get_artist_info\` - Get basic artist information  
-• \`get_album_info\` - Get basic album information
-• \`get_similar_artists\` - Find similar artists
-• \`get_similar_tracks\` - Find similar tracks`
+${renderToolList(PUBLIC_TOOL_CATALOG)}`
 		},
 		requiresAuth: () => {
 			const baseUrl = getBaseUrl()
@@ -108,14 +103,7 @@ You are not currently authenticated with Last.fm.
 Your MCP client should automatically prompt you to authenticate. If not, try disconnecting and reconnecting to this server.
 
 **Available without authentication:**
-• \`ping\` - Test server connectivity
-• \`server_info\` - Get server information
-• \`lastfm_auth_status\` - Check authentication status (this tool)
-• \`get_track_info\` - Get basic track information
-• \`get_artist_info\` - Get basic artist information
-• \`get_album_info\` - Get basic album information
-• \`get_similar_artists\` - Find similar artists
-• \`get_similar_tracks\` - Find similar tracks`,
+${renderToolList(PUBLIC_TOOL_CATALOG)}`,
 		requiresAuth: () =>
 			`🔐 **Authentication Required**
 
@@ -164,21 +152,7 @@ export function registerAuthenticatedTools(
 🎵 **Connected to:** Last.fm
 
 **Available Last.fm tools:**
-• \`get_recent_tracks\` - Get your recent listening history
-• \`get_top_artists\` - Get your top artists by time period
-• \`get_top_albums\` - Get your top albums by time period
-• \`get_loved_tracks\` - Get your loved/favorite tracks
-• \`get_track_info\` - Get detailed track information
-• \`get_artist_info\` - Get detailed artist information
-• \`get_album_info\` - Get detailed album information
-• \`get_user_info\` - Get your profile information
-• \`get_similar_artists\` - Find similar artists
-• \`get_similar_tracks\` - Find similar tracks
-• \`get_listening_stats\` - Get listening statistics
-• \`get_music_recommendations\` - Get personalized recommendations
-• \`get_weekly_chart_list\` - Get available historical time periods
-• \`get_weekly_artist_chart\` - Get artist listening data for specific periods
-• \`get_weekly_track_chart\` - Get track listening data for specific periods
+${renderToolList(AUTHENTICATED_TOOL_CATALOG)}
 
 **Examples to try:**
 - "Get my recent tracks"
@@ -339,8 +313,7 @@ Total artists: ${data.topartists['@attr'].total}`,
 				const albums = data.topalbums.album.slice(0, limit)
 				const albumList = albums
 					.map((album, index) => {
-						const artist = typeof album.artist === 'string' ? album.artist : album.artist.name
-						return `${index + 1}. ${artist} - ${album.name} (${album.playcount} plays)`
+						return `${index + 1}. ${formatArtist(album.artist)} - ${album.name} (${album.playcount} plays)`
 					})
 					.join('\n')
 

--- a/src/mcp/tools/catalog.ts
+++ b/src/mcp/tools/catalog.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Single source of truth for the human-readable tool list shown in auth-status messages.
+// ABOUTME: Auth-prompt messages render this catalog instead of hardcoding the list, so adding a tool only requires one edit.
+
+export interface ToolListEntry {
+	name: string
+	summary: string
+}
+
+/**
+ * Tools available without authentication.
+ * Add new public tools here so they show up in the unauthenticated auth-status / requiresAuth messages.
+ */
+export const PUBLIC_TOOL_CATALOG: ToolListEntry[] = [
+	{ name: 'ping', summary: 'Test server connectivity' },
+	{ name: 'server_info', summary: 'Get server information' },
+	{ name: 'lastfm_auth_status', summary: 'Check authentication status (this tool)' },
+	{ name: 'get_track_info', summary: 'Get basic track information' },
+	{ name: 'get_artist_info', summary: 'Get basic artist information' },
+	{ name: 'get_album_info', summary: 'Get basic album information' },
+	{ name: 'get_similar_artists', summary: 'Find similar artists' },
+	{ name: 'get_similar_tracks', summary: 'Find similar tracks' },
+]
+
+/**
+ * Tools that require authentication.
+ * Add new authenticated tools here so they show up in the authenticated auth-status message.
+ */
+export const AUTHENTICATED_TOOL_CATALOG: ToolListEntry[] = [
+	{ name: 'get_recent_tracks', summary: 'Get your recent listening history' },
+	{ name: 'get_top_artists', summary: 'Get your top artists by time period' },
+	{ name: 'get_top_albums', summary: 'Get your top albums by time period' },
+	{ name: 'get_loved_tracks', summary: 'Get your loved/favorite tracks' },
+	{ name: 'get_track_info', summary: 'Get detailed track information' },
+	{ name: 'get_artist_info', summary: 'Get detailed artist information' },
+	{ name: 'get_album_info', summary: 'Get detailed album information' },
+	{ name: 'get_user_info', summary: 'Get your profile information' },
+	{ name: 'get_similar_artists', summary: 'Find similar artists' },
+	{ name: 'get_similar_tracks', summary: 'Find similar tracks' },
+	{ name: 'get_listening_stats', summary: 'Get listening statistics' },
+	{ name: 'get_music_recommendations', summary: 'Get personalized recommendations' },
+	{ name: 'get_weekly_chart_list', summary: 'Get available historical time periods' },
+	{ name: 'get_weekly_artist_chart', summary: 'Get artist listening data for specific periods' },
+	{ name: 'get_weekly_track_chart', summary: 'Get track listening data for specific periods' },
+]
+
+/**
+ * Render a catalog as a markdown bullet list of `\`name\` - summary` lines.
+ */
+export function renderToolList(catalog: ToolListEntry[]): string {
+	return catalog.map((t) => `• \`${t.name}\` - ${t.summary}`).join('\n')
+}

--- a/src/mcp/tools/formatters.ts
+++ b/src/mcp/tools/formatters.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Shared formatting helpers for MCP tool responses.
+// ABOUTME: Normalises Last.fm fields that the API returns in mixed shapes (e.g. artist as string or object).
+
+/**
+ * Last.fm returns the `artist` field on tracks/albums either as a plain string
+ * or as an object `{ name, mbid?, url? }` depending on the endpoint and request
+ * shape. Normalise to the displayable name.
+ */
+export function formatArtist(artist: string | { name: string } | undefined | null): string {
+	if (!artist) return 'Unknown Artist'
+	if (typeof artist === 'string') return artist
+	return artist.name ?? 'Unknown Artist'
+}

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 
 import { CachedLastfmClient } from '../../clients/cachedLastfm'
 import { toolError } from './error-handler'
+import { formatArtist } from './formatters'
 
 /**
  * Register all public (non-authenticated) tools with the MCP server.
@@ -189,7 +190,7 @@ ${!username ? '*Note: Sign in to see your personal listening stats for this arti
 							text: `💿 **Album Information**
 
 **Album:** ${data.album.name}
-**Artist:** ${data.album.artist}
+**Artist:** ${formatArtist(data.album.artist)}
 
 **Stats:**
 • Total plays: ${data.album.playcount}


### PR DESCRIPTION
Closes #8.

## Summary
- Remove dead per-request throttle in `LastfmClient` and `LastfmAuth`. Both clients are instantiated per-request, so `lastRequestTime` never observed a previous request — the code did nothing useful while suggesting rate-limit safety we didn't actually have. Existing 429-aware retry in `utils/retry.ts` handles rate limits correctly.
- Extract the auth-status tool list into `mcp/tools/catalog.ts` with a shared `renderToolList` helper. Adding a tool now requires one edit instead of three.
- Add `formatArtist` helper for the `LastfmAlbum.artist` field, which Last.fm returns as either a string or `{ name, mbid?, url? }`. Fixes a latent `[object Object]` render in `get_album_info` and replaces an inline typeof check in `get_top_albums`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] All 46 tests touching changed code pass
- [x] Deployed to `lastfm-mcp-prod` and verified live: `ping`, `lastfm_auth_status`, `get_album_info`, `get_top_albums`