### PR TITLE
fix(mcp): normalize Last.fm list fields to arrays (closes #23)

### DIFF
--- a/src/clients/lastfm.ts
+++ b/src/clients/lastfm.ts
@@ -31,6 +31,25 @@ export interface LastfmTrack {
 	loved?: string
 }
 
+export interface LastfmTag {
+	name: string
+	url: string
+	count?: number
+}
+
+export interface LastfmAlbumTrack {
+	name: string
+	duration?: string
+	'@attr': {
+		rank: string
+	}
+	artist: {
+		name: string
+		mbid?: string
+		url?: string
+	}
+}
+
 export interface LastfmArtist {
 	name: string
 	playcount: string
@@ -56,14 +75,10 @@ export interface LastfmArtist {
 		content: string
 	}
 	similar?: {
-		artist: LastfmArtist[]
+		artist?: LastfmArtist | LastfmArtist[]
 	}
 	tags?: {
-		tag: Array<{
-			name: string
-			url: string
-			count?: number
-		}>
+		tag?: LastfmTag | LastfmTag[]
 	}
 }
 
@@ -250,12 +265,10 @@ export interface LastfmTrackInfoResponse {
 		playcount: string
 		userplaycount?: string
 		userloved?: string
+		// Last.fm returns `tag` as an array for many tags, a bare object for one,
+		// or omits it entirely. See toArray() in mcp/tools/formatters.ts.
 		toptags?: {
-			tag: Array<{
-				name: string
-				count: number
-				url: string
-			}>
+			tag?: LastfmTag | LastfmTag[]
 		}
 		wiki?: {
 			published: string
@@ -263,7 +276,7 @@ export interface LastfmTrackInfoResponse {
 			content: string
 		}
 		similar?: {
-			track: LastfmTrack[]
+			track?: LastfmTrack | LastfmTrack[]
 		}
 	}
 }
@@ -275,15 +288,11 @@ export interface LastfmArtistInfoResponse {
 			playcount: string
 			userplaycount?: string
 		}
-		similar: {
-			artist: LastfmArtist[]
+		similar?: {
+			artist?: LastfmArtist | LastfmArtist[]
 		}
-		tags: {
-			tag: Array<{
-				name: string
-				url: string
-				count?: number
-			}>
+		tags?: {
+			tag?: LastfmTag | LastfmTag[]
 		}
 		bio: {
 			published: string
@@ -298,26 +307,13 @@ export interface LastfmAlbumInfoResponse {
 		listeners: string
 		playcount: string
 		userplaycount?: string
-		tracks: {
-			track: Array<{
-				name: string
-				duration?: string
-				'@attr': {
-					rank: string
-				}
-				artist: {
-					name: string
-					mbid?: string
-					url?: string
-				}
-			}>
+		// Last.fm returns `track`/`tag` as an array for many, a bare object for
+		// one, or omits it entirely. See toArray() in mcp/tools/formatters.ts.
+		tracks?: {
+			track?: LastfmAlbumTrack | LastfmAlbumTrack[]
 		}
-		tags: {
-			tag: Array<{
-				name: string
-				url: string
-				count?: number
-			}>
+		tags?: {
+			tag?: LastfmTag | LastfmTag[]
 		}
 		wiki?: {
 			published: string

--- a/src/mcp/tools/formatters.ts
+++ b/src/mcp/tools/formatters.ts
@@ -11,3 +11,17 @@ export function formatArtist(artist: string | { name: string } | undefined | nul
 	if (typeof artist === 'string') return artist
 	return artist.name ?? 'Unknown Artist'
 }
+
+/**
+ * Last.fm serialises list fields (tags, tracks, similar artists, …) in three
+ * shapes depending on cardinality: an array for many, a bare object for exactly
+ * one, and an omitted key (or empty string) for none. Callers want to `.slice()`
+ * / `.map()` the result, so normalise every shape to an array.
+ *
+ * Passing a non-empty string returns `[]` — list items are always objects, so a
+ * string only ever represents Last.fm's "empty collection" sentinel.
+ */
+export function toArray<T>(value: T | T[] | undefined | null): T[] {
+	if (value == null || typeof value === 'string') return []
+	return Array.isArray(value) ? value : [value]
+}

--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { CachedLastfmClient } from '../../clients/cachedLastfm'
 import { buildNextSteps } from '../../utils/breadcrumb'
 import { toolError } from './error-handler'
-import { formatArtist } from './formatters'
+import { formatArtist, toArray } from './formatters'
 
 /**
  * Register all public (non-authenticated) tools with the MCP server.
@@ -79,7 +79,7 @@ To get started, authenticate at ${authUrl}${nextSteps}`,
 				const data = await client.getTrackInfo(artist, track, username)
 
 				const tags =
-					data.track.toptags?.tag
+					toArray(data.track.toptags?.tag)
 						.slice(0, 5)
 						.map((tag) => tag.name)
 						.join(', ') || 'None'
@@ -136,12 +136,12 @@ ${!username ? '*Note: Sign in to see your personal listening stats for this trac
 				const data = await client.getArtistInfo(artist, username)
 
 				const tags =
-					data.artist.tags?.tag
+					toArray(data.artist.tags?.tag)
 						.slice(0, 5)
 						.map((tag) => tag.name)
 						.join(', ') || 'None'
 				const similar =
-					data.artist.similar?.artist
+					toArray(data.artist.similar?.artist)
 						.slice(0, 5)
 						.map((a) => a.name)
 						.join(', ') || 'None'
@@ -195,12 +195,12 @@ ${!username ? '*Note: Sign in to see your personal listening stats for this arti
 				const data = await client.getAlbumInfo(artist, album, username)
 
 				const tags =
-					data.album.tags?.tag
+					toArray(data.album.tags?.tag)
 						.slice(0, 5)
 						.map((tag) => tag.name)
 						.join(', ') || 'None'
 				const tracks =
-					data.album.tracks?.track
+					toArray(data.album.tracks?.track)
 						.slice(0, 10)
 						.map((track, i) => `${i + 1}. ${track.name}`)
 						.join('\n') || 'Track listing not available'

--- a/test/mcp/tools/formatters.test.ts
+++ b/test/mcp/tools/formatters.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { formatArtist, toArray } from '../../../src/mcp/tools/formatters'
+
+describe('toArray', () => {
+	// Last.fm serialises a multi-element collection as an array.
+	it('returns an array unchanged', () => {
+		const input = [{ name: 'rock' }, { name: 'indie' }]
+		expect(toArray(input)).toEqual([{ name: 'rock' }, { name: 'indie' }])
+	})
+
+	// Last.fm serialises a single-element collection as a bare object, not an array.
+	it('wraps a single object in an array', () => {
+		const input = { name: 'rock' }
+		expect(toArray(input)).toEqual([{ name: 'rock' }])
+	})
+
+	// Last.fm omits empty collections entirely (undefined after optional chaining).
+	it('returns an empty array for undefined', () => {
+		expect(toArray(undefined)).toEqual([])
+	})
+
+	it('returns an empty array for null', () => {
+		expect(toArray(null)).toEqual([])
+	})
+
+	// Some Last.fm endpoints represent an empty collection as an empty string.
+	it('returns an empty array for an empty string', () => {
+		expect(toArray('' as unknown as { name: string })).toEqual([])
+	})
+
+	it('returns an empty array unchanged', () => {
+		expect(toArray([])).toEqual([])
+	})
+
+	// The downstream usage: .slice().map() must not throw for any of the shapes above.
+	it('supports slice/map chaining on a single-object input', () => {
+		const tags = toArray<{ name: string }>({ name: 'rock' })
+			.slice(0, 5)
+			.map((t) => t.name)
+			.join(', ')
+		expect(tags).toBe('rock')
+	})
+
+	it('supports slice/map chaining on an absent input', () => {
+		const tags = toArray<{ name: string }>(undefined)
+			.slice(0, 5)
+			.map((t) => t.name)
+			.join(', ')
+		expect(tags).toBe('')
+	})
+})
+
+describe('formatArtist', () => {
+	it('returns a string artist unchanged', () => {
+		expect(formatArtist('Radiohead')).toBe('Radiohead')
+	})
+
+	it('extracts name from an object artist', () => {
+		expect(formatArtist({ name: 'Radiohead' })).toBe('Radiohead')
+	})
+
+	it('falls back to Unknown Artist for nullish input', () => {
+		expect(formatArtist(undefined)).toBe('Unknown Artist')
+		expect(formatArtist(null)).toBe('Unknown Artist')
+	})
+})


### PR DESCRIPTION
## Summary

`get_album_info` (and, latently, `get_track_info` / `get_artist_info`) threw an uncaught `TypeError` whenever a Last.fm list field — tags, tracks, similar artists — came back as anything other than a multi-element array.

Last.fm serialises these fields in three shapes by cardinality:
- **many** → array
- **exactly one** → bare object (not an array)
- **none** → key omitted (or empty string)

The handlers called `.slice()` directly, so a single-element collection threw `slice is not a function` and an absent one threw `Cannot read properties of undefined (reading 'slice')`. The `|| 'None'` fallbacks were dead code — the throw happened while evaluating the left operand of `||`.

Production Workers Observability showed ~40 errors/week from `get_album_info` alone (against ~51k requests). `get_track_info` and `get_artist_info` carried the identical latent bug.

Fixes #23.

## Changes

- **`toArray()` helper** in `src/mcp/tools/formatters.ts` — normalises array / single-object / absent into an array.
- Applied at **all five** call sites: `get_track_info` (toptags), `get_artist_info` (tags + similar), `get_album_info` (tags + tracks).
- **Honest types** in `src/clients/lastfm.ts` — widened the five collection fields from `Array<…>` to `Item | Item[]` (optional), and extracted shared `LastfmTag` / `LastfmAlbumTrack` interfaces.

## Testing

TDD — tests written first, watched fail, then implemented.

- New `test/mcp/tools/formatters.test.ts` covers array / single-object / undefined / null / empty-string, plus the `.slice().map()` chain that previously threw.
- `tsc --noEmit` clean
- Full suite: **166 passed**
- `npm run lint` clean

> Note: the `public.ts` diff is intentionally limited to the functional change. `prettier --write` wanted to reformat several pre-existing unrelated lines (the file was already non-prettier-clean on `main`); that churn was left out to keep the bugfix focused.